### PR TITLE
Images sub-package wasn't in setup.py's packages.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     platforms=['any'],
     packages=[
         'qrcode',
+        'qrcode.images',
     ],
     scripts=[
         'scripts/qr',


### PR DESCRIPTION
Added images sub-module to setup.py packages so pip install doesn't throw an ImportError.
