### PR TITLE
Add dependency for PIL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ setup(
     author='Lincoln Loop',
     author_email='info@lincolnloop.com',
     platforms=['any'],
+    install_requires=[
+        "pil",
+    ],
     packages=[
         'qrcode',
         'qrcode.image',


### PR DESCRIPTION
A minial virtualenv setup does not provide PIL automatically.

When I was installing python-qrcode in a fresh virtualenv on a centos system (does not matter), the code did not work, since qrcode was missing the Python image library.
