### PR TITLE
Fixed ValueError when install on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     scripts=[
         'scripts/qr',
     ],
-    data_files=[('share/man/man1/', ['doc/qr.1'])],
+    data_files=[('share/man/man1', ['doc/qr.1'])],
     package_data={'': ['LICENSE']},
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
When install on Windows, it raise ValueError:

```
pip install qrcode -U
Downloading/unpacking qrcode
Downloading qrcode-2.5.tar.gz
Running setup.py egg_info for package qrcode
Installing collected packages: qrcode
Running setup.py install for qrcode
    Traceback (most recent call last):
    File "<string>", line 1, in <module>

    ... 

            dir = convert_path(f[0])
    File "C:\Python26\lib\distutils\util.py", line 201, in convert_path
        raise ValueError, "path '%s' cannot end with '/'" % pathname
    ValueError: path 'share/man/man1/' cannot end with '/'
```
