### PR TITLE
Changes for Python3.2 compatability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,16 @@
 *.pyc
+*.pyo
+.installed.cfg
+bin
+build
+develop-eggs
+dist
+downloads
+eggs
+*.egg-info
+parts
+src/*.egg-info
+lib
+lib64*.pyc
+
+venv

--- a/qrcode/util.py
+++ b/qrcode/util.py
@@ -255,13 +255,7 @@ class QRData:
         chosen.
         """
         # Convert data to a (utf-8 encoded) byte-string.
-        if not isinstance(data, basestring):
-            try:
-                data = str(data)
-            except UnicodeEncodeError:
-                data = unicode(data)
-        if isinstance(data, unicode):
-            data = data.encode('utf-8')
+        data = str(data)
 
         if data.isdigit():
             auto_mode = MODE_NUMBER

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='qrcode',
@@ -29,5 +29,8 @@ setup(
         'Programming Language :: Python',
         'Topic :: Multimedia :: Graphics',
         'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
+    install_requires=[
+        'pillow >= 2.0.0',
     ],
 )


### PR DESCRIPTION
I needed python-qrcode in a Python3 project, so I made changes for it to work. I have not tested extensively, but it works with my small tests.

The code changes involved removing code to ensure data was in unicode format. Python3 is unicode by default, so this conversion is unnecessary.

I also added a dependency for pillow, which is a maintained Python3 fork of PIL.
