### PR TITLE
Fix PymagingImage cannot save

### DIFF
--- a/qrcode/image/base.py
+++ b/qrcode/image/base.py
@@ -43,11 +43,16 @@ class BaseImage(object):
         """
         Get the image type.
         """
+        orig_kind = None
         if kind is None:
             kind = self.kind
         if transform:
+            orig_kind = kind
             kind = transform(kind)
-        if self.allowed_kinds and kind not in self.allowed_kinds:
+        if self.allowed_kinds and not (
+            (kind in self.allowed_kinds) or 
+            (orig_kind in self.allowed_kinds if orig_kind else False)
+            ):
             raise ValueError(
                 "Cannot set %s type to %s" % (type(self).__name__, kind))
         return kind

--- a/qrcode/tests.py
+++ b/qrcode/tests.py
@@ -1,4 +1,4 @@
-import sys
+import sys, io
 
 ANCIENT_PYTHON = sys.version_info[:2] < (2, 6)
 
@@ -67,20 +67,23 @@ class QRCodeTests(unittest.TestCase):
         self.assertEqual(qr.data_list[0].mode, MODE_8BIT_BYTE)
 
     def test_render_svg(self):
+        buf = io.BytesIO()
         qr = qrcode.QRCode()
         qr.add_data(UNICODE_TEXT)
-        qr.make_image(image_factory=qrcode.image.svg.SvgImage)
+        qr.make_image(image_factory=qrcode.image.svg.SvgImage).save(buf)
 
     def test_render_svg_path(self):
+        buf = io.BytesIO()
         qr = qrcode.QRCode()
         qr.add_data(UNICODE_TEXT)
-        qr.make_image(image_factory=qrcode.image.svg.SvgPathImage)
+        qr.make_image(image_factory=qrcode.image.svg.SvgPathImage).save(buf)
 
     @unittest.skipIf(ANCIENT_PYTHON, "Only Python 2.6 and greater")
     def test_render_pymaging_png(self):
+        buf = io.BytesIO()
         qr = qrcode.QRCode()
         qr.add_data(UNICODE_TEXT)
-        qr.make_image(image_factory=qrcode.image.pure.PymagingImage)
+        qr.make_image(image_factory=qrcode.image.pure.PymagingImage).save(buf)
 
     def test_optimize(self):
         qr = qrcode.QRCode()


### PR DESCRIPTION
If one uses `PymagingImage` as their QRCode's `image_factory`, the image_factory transforms its `kind` of "PNG" to "png" for compatibility with the library `pymaging_png`, and its super's `check_kind()` checks for the _transformed_ value in the instance's `allowed_kinds` tuple, where it does not exist.

I've fixed this by modifying `BaseImage.check_kind()` to check for either the original or transformed value in `allowed_kinds`.

This did not appear in the tests because this is only triggered on calling the image's `save()`, and the tests stop at `make_image()`. I've therefore modified the render tests to save to an `io.BytesIO` object, which I believe is the most compatible (2 to 3) way of doing this.
