### PR TITLE
hyphen-used-as-minus-sign in qr.1

### DIFF
--- a/doc/qr.1
+++ b/doc/qr.1
@@ -3,19 +3,19 @@
 .SH NAME
 qr \- script to create QR codes at the command line
 .SH SYNOPSIS
-qr [--help] [--factory=FACTORY] [--optimize=OPTIMIZE] [data]
+qr [\-\-help] [\-\-factory=FACTORY] [\-\-optimize=OPTIMIZE] [data]
 .SH DESCRIPTION
 This script uses the python qrcode module. It can take data from stdin or from the commandline and generate a QR code.
 Normally it will output the QR code as ascii art to the terminal. If the output is piped to a file, it will output the image (default type of PNG).
 .SH OPTIONS
 .PP
-\fB\ -h, --help\fR
+\fB\ \-h, \-\-help\fR
 .RS 4
 Show a help message.
 .RE
 
 .PP
-\fB\ --factory=FACTORY\fR
+\fB\ \-\-factory=FACTORY\fR
 .RS 4
 Full python path to the image factory class to create the
 image with. You can use the following shortcuts to the
@@ -24,7 +24,7 @@ svg, svg-fragment, svg-path.
 .RE
 
 .PP
-\fB\ --optimize=OPTIMIZE\fR
+\fB\ \-\-optimize=OPTIMIZE\fR
 .RS 4
 Optimize the data by looking for chunks of at least this
 many characters that could use a more efficient encoding


### PR DESCRIPTION
Lintian complains:
"This manual page seems to contain a hyphen where a minus sign was
intended. By default, "-" chars are interpreted as hyphens (U+2010) by
groff, not as minus signs (U+002D). Since options to programs use minus
signs (U+002D), this means for example in UTF-8 locales that you cannot
cut and paste options, nor search for them easily. The Debian groff
package currently forces "-" to be interpreted as a minus sign due to
the number of manual pages with this problem, but this is a
Debian-specific modification and hopefully eventually can be removed."
