### PR TITLE
Add absolute_import directive to the PIL backend

### DIFF
--- a/qrcode/image/pil.py
+++ b/qrcode/image/pil.py
@@ -1,3 +1,6 @@
+# Needed on case-insensitive filesystems
+from __future__ import absolute_import
+
 # Try to import PIL in either of the two ways it can be installed.
 try:
     from PIL import Image, ImageDraw


### PR DESCRIPTION
Needed for case-insensitive filesystems, such as VirtualBox's shared folders feature.
