### PR TITLE
Output encoding for print_ascii on Python 2.6

### DIFF
--- a/qrcode/main.py
+++ b/qrcode/main.py
@@ -201,7 +201,11 @@ class QRCode:
         """
         if out is None:
             import sys
-            out = sys.stdout
+            if sys.version_info < (2, 7):
+                import codecs
+                out = codecs.getwriter(sys.stdout.encoding)(sys.stdout)
+            else:
+                out = sys.stdout
 
         if tty and not out.isatty():
             raise OSError("Not a tty")


### PR DESCRIPTION
This makes write() work the same as on 2.7/3, or the print statement on
2.6. None of these will work if stdout is redirected; in that case, we
aren't in any better position to guess the encoding than Python. This
isn't a problem for the basic script usage, as it only uses print_ascii
if stdout is a TTY.

Fixes #79 