### PR TITLE
Add get_image function.

### DIFF
--- a/qrcode/image/base.py
+++ b/qrcode/image/base.py
@@ -38,6 +38,12 @@ class BaseImage(object):
         Build the image class. Subclasses should return the class created.
         """
         return None
+        
+    def get_image(self, **kwargs):
+        """
+        Return the image class for further processing.
+        """
+        return _img
 
     def check_kind(self, kind, transform=None):
         """


### PR DESCRIPTION
get_image function would be useful for those, who need to obtain PIL.Image or ElementTree object for further processing instead of a BaseImage wrapper.