### PR TITLE
Add 'format' parameter to PilImage class

### DIFF
--- a/qrcode/image/pil.py
+++ b/qrcode/image/pil.py
@@ -26,10 +26,12 @@ class PilImage(qrcode.image.base.BaseImage):
         box = self.pixel_box(row, col)
         self._idr.rectangle(box, fill="black")
 
-    def save(self, stream, kind=None):
-        if kind is None:
-            kind = self.kind
-        self._img.save(stream, kind)
+    def save(self, stream, format=None, **kwargs):
+        if format is None:
+            format = kwargs.get("kind", self.kind)
+        if "kind" in kwargs:
+            del kwargs["kind"]
+        self._img.save(stream, format=format, **kwargs)
 
     def __getattr__(self, name):
         return getattr(self._img, name)


### PR DESCRIPTION
Matches interface of PIL/pillow's "Image" class for specifying format; see http://pillow.readthedocs.org/en/3.0.x/reference/Image.html#PIL.Image.Image.save

Additionally, passes through the kwargs, the same way as in pillow. I've kept the reading of the "kind" attribute so as not to break any existing interfaces.