### PR TITLE
Added colorama to console_scripts so as to display correctly on MS

### DIFF
--- a/qrcode/console_scripts.py
+++ b/qrcode/console_scripts.py
@@ -9,6 +9,10 @@ import sys
 import optparse
 import os
 import qrcode
+# The next two lines added to get the terminal to display properly on MS platforms
+import colorama
+
+colorama.init()
 
 default_factories = {
     'pil': 'qrcode.image.pil.PilImage',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
             'qr = qrcode.console_scripts:main',
         ],
     },
-    install_requires=['six'],
+    install_requires=['six', 'colorama'],
     data_files=[('share/man/man1', ['doc/qr.1'])],
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
The MS command line doesn't support ANSI codes by default which results in a mess.  Adding colorama.init() to the console_scripts corrects this painlessly. 

Also added colorama to the setup.py requires list.