### PR TITLE
Only import and init() colorama on MS platforms

### DIFF
--- a/qrcode/console_scripts.py
+++ b/qrcode/console_scripts.py
@@ -9,10 +9,10 @@ import sys
 import optparse
 import os
 import qrcode
-# The next two lines added to get the terminal to display properly on MS platforms
-import colorama
-
-colorama.init()
+# The next block is added to get the terminal to display properly on MS platforms
+if sys.platform.startswith(('win', 'cygwin')):
+    import colorama
+    colorama.init()
 
 default_factories = {
     'pil': 'qrcode.image.pil.PilImage',

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import io
 import os
 from setuptools import setup, find_packages
+import sys
 
 
 def long_description():
@@ -17,6 +18,11 @@ def long_description():
             content.append(f.read())
     return '\n\n'.join(content)
 
+# Colorama is needed for proper terminal support on MS platforms
+if sys.platform.startswith(('win', 'cygwin')):
+    dependencies = ['six', 'colorama']
+else:
+    dependencies = ['six']
 
 setup(
     name='qrcode',
@@ -34,7 +40,7 @@ setup(
             'qr = qrcode.console_scripts:main',
         ],
     },
-    install_requires=['six', 'colorama'],
+    install_requires=dependencies,
     data_files=[('share/man/man1', ['doc/qr.1'])],
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
Implements an on-needed basis for import of the colorama module, such that Unix
systems are not loading or initializing the colorama code when it is strictly
not necessary to do so.