### PR TITLE
Support wheels w/ Windows Colorama dependency logic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,6 @@ def long_description():
     return '\n\n'.join(content)
 
 
-# Colorama is needed for proper terminal support on MS platforms
-if sys.platform.startswith(('win', 'cygwin')):
-    dependencies = ['six', 'colorama']
-else:
-    dependencies = ['six']
-
 setup(
     name='qrcode',
     version='5.3.post',
@@ -41,7 +35,11 @@ setup(
             'qr = qrcode.console_scripts:main',
         ],
     },
-    install_requires=dependencies,
+    install_requires=['six'],
+    extra_requires={
+        ':sys_platform==win32': ['colorama'],
+        ':sys_platform==cygwin': ['colorama']
+    },
     data_files=[('share/man/man1', ['doc/qr.1'])],
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
Since when installing a wheel the setup.py is not executed (setup.py is only
used to build it), the branching statement I originally implemented does not
successfully install Colorama for Windows users in the general case.

The way to do this is with conditional dependencies in the setup suite as
specified in
https://wheel.readthedocs.io/en/latest/#defining-conditional-dependencies.

This code should bring in Colorama as a dependency when python-qrcode is
installed on Windows, regardless of the installation method.

Fixes #131.