### PR TITLE
Add qrcode.image.pygame.PygameSurface to create QRCodes as pygame Surfaces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,4 +160,7 @@ Or in Python::
 
     import qrcode
     from qrcode.image.pygame import PygameSurface
-    surface = qrcode.make('Some data here', image_factory=PygameSurface)
+    # this returns something that acts like a Surface
+    img = qrcode.make('Some data here', image_factory=PygameSurface)
+    # this fetches the underlying Surface
+    surface = img.get_image()

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Other image factories
 =====================
 
 You can encode as SVG, or use a new pure Python image processor to encode to
-PNG images.
+PNG images, or use Pygame to create a QRCode as a Surface.
 
 The Python examples below use the ``make`` shortcut. The same ``image_factory``
 keyword argument is a valid option for the ``QRCode`` class for more advanced
@@ -142,3 +142,22 @@ Or in Python::
     import qrcode
     from qrcode.image.pure import PymagingImage
     img = qrcode.make('Some data here', image_factory=PymagingImage)
+
+PyGame
+------
+
+Pygame supports BMP, JPG/JPEG, PNG, and TGA.
+
+Install the pygame package::
+
+    pip install pygame
+
+From your command line::
+
+    qr --factory=pygame "Some text" > test.png
+
+Or in Python::
+
+    import qrcode
+    from qrcode.image.pygame import PygameSurface
+    surface = qrcode.make('Some data here', image_factory=PygameSurface)

--- a/qrcode/console_scripts.py
+++ b/qrcode/console_scripts.py
@@ -16,6 +16,7 @@ if sys.platform.startswith(('win', 'cygwin')):
 
 default_factories = {
     'pil': 'qrcode.image.pil.PilImage',
+    'pygame': 'qrcode.image.pygame.PygameSurface',
     'pymaging': 'qrcode.image.pure.PymagingImage',
     'svg': 'qrcode.image.svg.SvgImage',
     'svg-fragment': 'qrcode.image.svg.SvgFragmentImage',

--- a/qrcode/image/pygame.py
+++ b/qrcode/image/pygame.py
@@ -34,3 +34,6 @@ class PygameSurface(qrcode.image.base.BaseImage):
         stream.write(tmpfp.read())
         tmpfp.close()
         os.remove(tmpname)
+
+    def __getattr__(self, name):
+        return getattr(self._img, name)

--- a/qrcode/image/pygame.py
+++ b/qrcode/image/pygame.py
@@ -1,0 +1,23 @@
+class PygameSurface(qrcode.image.base.BaseImage):
+
+    def new_image(self, **kwargs):
+        back_color = pygame.Color(kwargs.get("back_color", "white"))
+        fill_color = pygame.Color(kwargs.get("fill_color", "black"))
+        self.fill_color = fill_color
+        surface = pygame.Surface((self.pixel_size, self.pixel_size))
+        surface.fill(back_color)
+        return surface
+
+    def drawrect(self, row, col):
+        rect = pygame.Rect(self.pixel_box(row, col)[0], (self.box_size,self.box_size))
+        self._img.fill(color=self.fill_color, rect=rect)
+
+    def save(self, stream, format=None, **kwargs):
+        if format is None:
+            format = kwargs.pop("kind", self.kind)
+        tmpfd, tmpname = tempfile.mkstemp(suffix='.'+kind)
+        pygame.image_save(self._img, tmpname)
+        tmpfp = os.fdopen(tmpfd)
+        stream.write(tmpfp.read())
+        tmpfp.close()
+        os.remove(tmpname)

--- a/qrcode/image/pygame.py
+++ b/qrcode/image/pygame.py
@@ -1,3 +1,11 @@
+from __future__ import absolute_import
+import os
+import tempfile
+
+import pygame
+import qrcode.image.base
+
+
 class PygameSurface(qrcode.image.base.BaseImage):
 
     def new_image(self, **kwargs):

--- a/qrcode/image/pygame.py
+++ b/qrcode/image/pygame.py
@@ -22,9 +22,9 @@ class PygameSurface(qrcode.image.base.BaseImage):
         rect = pygame.Rect(self.pixel_box(row, col)[0], (self.box_size,self.box_size))
         self._img.fill(color=self.fill_color, rect=rect)
 
-    def save(self, stream, format=None, **kwargs):
-        if format is None:
-            format = kwargs.pop("kind", self.kind)
+    def save(self, stream, kind=None, **kwargs):
+        if kind is None:
+            kind = kwargs.pop("kind", self.kind)
         tmpfd, tmpname = tempfile.mkstemp(suffix='.'+kind)
         pygame.image.save(self._img, tmpname)
         tmpfp = os.fdopen(tmpfd)

--- a/qrcode/image/pygame.py
+++ b/qrcode/image/pygame.py
@@ -25,6 +25,9 @@ class PygameSurface(qrcode.image.base.BaseImage):
     def save(self, stream, kind=None, **kwargs):
         if kind is None:
             kind = kwargs.pop("kind", self.kind)
+
+        if kind.lower() not in ('bmp', 'jpg', 'jpeg', 'png', 'tga'):
+            raise ValueError('Unsupported file kind {0}'.format(kind))
         tmpfd, tmpname = tempfile.mkstemp(suffix='.'+kind)
         pygame.image.save(self._img, tmpname)
         tmpfp = os.fdopen(tmpfd)

--- a/qrcode/image/pygame.py
+++ b/qrcode/image/pygame.py
@@ -22,12 +22,13 @@ class PygameSurface(qrcode.image.base.BaseImage):
         rect = pygame.Rect(self.pixel_box(row, col)[0], (self.box_size,self.box_size))
         self._img.fill(color=self.fill_color, rect=rect)
 
-    def save(self, stream, kind=None, **kwargs):
+    def save(self, stream, kind=None):
         if kind is None:
-            kind = kwargs.pop("kind", self.kind)
+            kind = self.kind
 
         if kind.lower() not in ('bmp', 'jpg', 'jpeg', 'png', 'tga'):
             raise ValueError('Unsupported file kind {0}'.format(kind))
+
         tmpfd, tmpname = tempfile.mkstemp(suffix='.'+kind)
         pygame.image.save(self._img, tmpname)
         tmpfp = os.fdopen(tmpfd)

--- a/qrcode/image/pygame.py
+++ b/qrcode/image/pygame.py
@@ -8,6 +8,8 @@ import qrcode.image.base
 
 class PygameSurface(qrcode.image.base.BaseImage):
 
+    kind = 'PNG'
+
     def new_image(self, **kwargs):
         back_color = pygame.Color(kwargs.get("back_color", "white"))
         fill_color = pygame.Color(kwargs.get("fill_color", "black"))

--- a/qrcode/image/pygame.py
+++ b/qrcode/image/pygame.py
@@ -26,7 +26,7 @@ class PygameSurface(qrcode.image.base.BaseImage):
         if format is None:
             format = kwargs.pop("kind", self.kind)
         tmpfd, tmpname = tempfile.mkstemp(suffix='.'+kind)
-        pygame.image_save(self._img, tmpname)
+        pygame.image.save(self._img, tmpname)
         tmpfp = os.fdopen(tmpfd)
         stream.write(tmpfp.read())
         tmpfp.close()

--- a/qrcode/tests/test_qrcode.py
+++ b/qrcode/tests/test_qrcode.py
@@ -11,6 +11,12 @@ try:
 except ImportError:  # pragma: no cover
     pymaging_png = None
 
+try:
+    import qrcode.image.pygame
+    import pygame
+except ImportError:  # pragma: no cover
+    pygame = None
+
 import qrcode
 from qrcode.image.base import BaseImage
 from qrcode.exceptions import DataOverflowError
@@ -161,6 +167,23 @@ class QRCodeTests(unittest.TestCase):
         qr = qrcode.QRCode()
         qr.add_data(UNICODE_TEXT)
         img = qr.make_image(image_factory=qrcode.image.pure.PymagingImage)
+        self.assertRaises(ValueError, img.save, six.BytesIO(), kind='FISH')
+
+    @unittest.skipIf(not pygame, "Requires pygame")
+    def test_render_pygame_png(self):
+        qr = qrcode.QRCode()
+        qr.add_data(UNICODE_TEXT)
+        img = qr.make_image(image_factory=qrcode.image.pygame.PygameSurface)
+        with warnings.catch_warnings():
+            if six.PY3:
+                warnings.simplefilter('ignore', DeprecationWarning)
+            img.save(six.BytesIO())
+
+    @unittest.skipIf(not pygame, "Requires pygame")
+    def test_render_pygame_bad_kind(self):
+        qr = qrcode.QRCode()
+        qr.add_data(UNICODE_TEXT)
+        img = qr.make_image(image_factory=qrcode.image.pygame.PygameSurface)
         self.assertRaises(ValueError, img.save, six.BytesIO(), kind='FISH')
 
     def test_optimize(self):

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     pillow
     git+git://github.com/ojii/pymaging.git#egg=pymaging
     git+git://github.com/ojii/pymaging-png.git#egg=pymaging-png
+    pygame
 commands =
     {envbindir}/coverage run -a --source qrcode -m unittest {posargs:discover qrcode}
 


### PR DESCRIPTION
I'm creating a program with pygame to handle the graphics, and wanted to display a QR code. Converting a PIL Image to a Surface was a bit fiddly, and writing a new image factory which creates pygame Surfaces was pretty easy.