### PR TITLE
image/svg.py: don't duplicate curves with every save

### DIFF
--- a/qrcode/image/svg.py
+++ b/qrcode/image/svg.py
@@ -141,6 +141,7 @@ class SvgPathImage(SvgImage):
         )
 
     def _write(self, stream):
+        self._img = self.new_image()
         self._img.append(self.make_path())
         super(SvgPathImage, self)._write(stream)
 


### PR DESCRIPTION
Before this change a copy of the output curve was appended to _img with every call to save. This resulted in multiple layers of the same qr code curve, only recognizable by moving around the nodes of the top layer curve.