### PR TITLE
Printing QR with circles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 qrcode.egg-info/
 .pytest_cache/
 .idea/
+venv/

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ For more control, use the ``QRCode`` class. For example:
         error_correction=qrcode.constants.ERROR_CORRECT_L,
         box_size=10,
         border=4,
+        style="circle",
     )
     qr.add_data('Some data')
     qr.make(fit=True)
@@ -80,6 +81,10 @@ is.
 
 The ``border`` parameter controls how many boxes thick the border should be
 (the default is 4, which is the minimum according to the specs).
+
+The ``style`` parameter when set to ``circles`` change squares in the QR
+to be printed as circles.
+
 
 Other image factories
 =====================

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ For more control, use the ``QRCode`` class. For example:
         error_correction=qrcode.constants.ERROR_CORRECT_L,
         box_size=10,
         border=4,
-        style="circle",
+        style="circles",
     )
     qr.add_data('Some data')
     qr.make(fit=True)

--- a/qrcode/image/pil.py
+++ b/qrcode/image/pil.py
@@ -42,6 +42,10 @@ class PilImage(qrcode.image.base.BaseImage):
         box = self.pixel_box(row, col)
         self._idr.rectangle(box, fill=self.fill_color)
 
+    def drawcirc(self, row, col):
+        box = self.pixel_box(row, col)
+        self._idr.ellipse((box[0][0], box[0][1], box[1][0] - 1, box[1][1] - 1), fill=self.fill_color)
+
     def save(self, stream, format=None, **kwargs):
         kind = kwargs.pop("kind", self.kind)
         if format is None:

--- a/qrcode/main.py
+++ b/qrcode/main.py
@@ -1,8 +1,9 @@
-from qrcode import constants, exceptions, util
-from qrcode.image.base import BaseImage
+from bisect import bisect_left
 
 import six
-from bisect import bisect_left
+
+from qrcode import constants, exceptions, util
+from qrcode.image.base import BaseImage
 
 
 def make(data=None, **kwargs):
@@ -34,7 +35,8 @@ class QRCode(object):
                  error_correction=constants.ERROR_CORRECT_M,
                  box_size=10, border=4,
                  image_factory=None,
-                 mask_pattern=None):
+                 mask_pattern=None,
+                 style=None):
         _check_box_size(box_size)
         self.version = version and int(version)
         self.error_correction = int(error_correction)
@@ -44,6 +46,7 @@ class QRCode(object):
         self.border = int(border)
         _check_mask_pattern(mask_pattern)
         self.mask_pattern = mask_pattern
+        self.style = style
         self.image_factory = image_factory
         if image_factory is not None:
             assert issubclass(image_factory, BaseImage)
@@ -285,10 +288,16 @@ class QRCode(object):
 
         im = image_factory(
             self.border, self.modules_count, self.box_size, **kwargs)
-        for r in range(self.modules_count):
-            for c in range(self.modules_count):
-                if self.modules[r][c]:
-                    im.drawrect(r, c)
+        if self.style is "circles":
+            for r in range(self.modules_count):
+                for c in range(self.modules_count):
+                    if self.modules[r][c]:
+                        im.drawcirc(r, c)
+        else:
+            for r in range(self.modules_count):
+                for c in range(self.modules_count):
+                    if self.modules[r][c]:
+                        im.drawrect(r, c)
         return im
 
     def setup_timing_pattern(self):

--- a/qrcode/tests/test_qrcode.py
+++ b/qrcode/tests/test_qrcode.py
@@ -1,8 +1,10 @@
-import warnings
-import six
 import sys
-import qrcode.util
+import warnings
+
+import six
+
 import qrcode.image.svg
+import qrcode.util
 
 try:
     import qrcode.image.pure
@@ -117,6 +119,12 @@ class QRCodeTests(unittest.TestCase):
         qr = qrcode.QRCode()
         qr.add_data(UNICODE_TEXT)
         img = qr.make_image(back_color='red')
+        img.save(six.BytesIO())
+
+    def test_render_pil_with_circles(self):
+        qr = qrcode.QRCode()
+        qr.add_data(UNICODE_TEXT)
+        img = qr.make_image(style='circles')
         img.save(six.BytesIO())
 
     def test_render_with_pattern(self):


### PR DESCRIPTION
Created ``style`` parameter.  
When set to ``circles`` change squares in the QR
to circles.

![image](https://user-images.githubusercontent.com/6259132/55112420-da7a8300-50dc-11e9-803f-bcf60260f38a.png)
