### PR TITLE
Add a --output command line option

### DIFF
--- a/qrcode/console_scripts.py
+++ b/qrcode/console_scripts.py
@@ -50,6 +50,11 @@ def main(args=None):
         choices=sorted(error_correction.keys()), default='M',
         help="The error correction level to use. Choices are L (7%), "
         "M (15%, default), Q (25%), and H (30%).")
+    parser.add_option(
+        "--output",
+        help="The output file. If not specified, the image is sent to "
+        "the standard output.")
+
     opts, args = parser.parse_args(args)
 
     qr = qrcode.QRCode(
@@ -77,23 +82,28 @@ def main(args=None):
     else:
         qr.add_data(data, optimize=opts.optimize)
 
-    if image_factory is None and os.isatty(sys.stdout.fileno()):
-        qr.print_ascii(tty=True)
-        return
+    if opts.output:
+        img = qr.make_image(image_factory=image_factory)
+        with open(opts.output, "wb") as out:
+            img.save(out)
+    else:
+        if image_factory is None and os.isatty(sys.stdout.fileno()):
+            qr.print_ascii(tty=True)
+            return
 
-    img = qr.make_image(image_factory=image_factory)
+        img = qr.make_image(image_factory=image_factory)
 
-    sys.stdout.flush()
-    # Use sys.stdout.buffer if available (Python 3), avoiding
-    # UnicodeDecodeErrors.
-    stdout_buffer = getattr(sys.stdout, 'buffer', None)
-    if not stdout_buffer:
-        if sys.platform == 'win32':  # pragma: no cover
-            import msvcrt
-            msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
-        stdout_buffer = sys.stdout
+        sys.stdout.flush()
+        # Use sys.stdout.buffer if available (Python 3), avoiding
+        # UnicodeDecodeErrors.
+        stdout_buffer = getattr(sys.stdout, 'buffer', None)
+        if not stdout_buffer:
+            if sys.platform == 'win32':  # pragma: no cover
+                import msvcrt
+                msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
+            stdout_buffer = sys.stdout
 
-    img.save(stdout_buffer)
+        img.save(stdout_buffer)
 
 
 if __name__ == "__main__":

--- a/qrcode/tests/test_script.py
+++ b/qrcode/tests/test_script.py
@@ -1,4 +1,6 @@
 import sys
+import os
+from tempfile import mkdtemp
 try:
     import unittest2 as unittest
 except ImportError:
@@ -16,7 +18,12 @@ def bad_read():
 
 
 class ScriptTest(unittest.TestCase):
-
+    def setUp(self):
+        self.tmpdir = mkdtemp()
+        
+    def tearDown(self):
+        os.rmdir(self.tmpdir)
+        
     @mock.patch('os.isatty', lambda *args: True)
     @mock.patch('qrcode.main.QRCode.print_ascii')
     def test_isatty(self, mock_print_ascii):
@@ -65,3 +72,9 @@ class ScriptTest(unittest.TestCase):
     @mock.patch('sys.stderr')
     def test_bad_factory(self, mock_stderr):
         self.assertRaises(SystemExit, main, 'testtext --factory fish'.split())
+
+    def test_output(self):
+        tmpfile = os.path.join(self.tmpdir, "test.png")
+        main(['testtext', '--output', tmpfile])
+        os.remove(tmpfile)
+        


### PR DESCRIPTION
I was trying to use qrcode with Windows Powershell and it proved surprisingly difficult to pipe binary data out of `qr` and into a file without PowerShell altering it in some way, for example LF->CRLF and Unicode encodings. To help this I added an extra option to specify the output file. Now you can do
```
qr --output=code.png "some data"
```
instead of
```
qr "some data" > code.png
```
If you omit the `output` option, output goes to standard out, so `qr` works exactly as before.