### PR TITLE
Add editable to the pip install command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,8 +135,8 @@ Pure Python PNG
 
 Install the following two packages::
 
-    pip install git+git://github.com/ojii/pymaging.git#egg=pymaging
-    pip install git+git://github.com/ojii/pymaging-png.git#egg=pymaging-png
+    pip install -e git+git://github.com/ojii/pymaging.git#egg=pymaging
+    pip install -e git+git://github.com/ojii/pymaging-png.git#egg=pymaging-png
 
 From your command line::
 


### PR DESCRIPTION
If you freeze your pip file, or even worse you run it in a container that depends on your requirements.txt the -e flag helps you to get:
-e git://github.com/ojii/pymaging.git@596a08fce5664e58d6e8c96847393fbe987783f2#egg=pymaging
-e git://github.com/ojii/pymaging-png.git@83d85c44e4b2342818e6c068065e031a9f81bb9f#egg=pymaging_png

instead of the (normal looking, but failing)

pymaging==0.1
pymaging-png==0.1

which will fail terribly (see https://pip.readthedocs.io/en/stable/reference/pip_install/#git).