### PR TITLE
Make it possible to pass in other supported color types, e.g. RGB tup…

### DIFF
--- a/qrcode/image/pil.py
+++ b/qrcode/image/pil.py
@@ -21,8 +21,18 @@ class PilImage(qrcode.image.base.BaseImage):
         back_color = kwargs.get("back_color", "white")
         fill_color = kwargs.get("fill_color", "black")
 
-        if fill_color.lower() != "black" or back_color.lower() != "white":
-            if back_color.lower() == "transparent":
+        try:
+            fill_color = fill_color.lower()
+        except AttributeError:
+            pass
+
+        try:
+            back_color = back_color.lower()
+        except AttributeError:
+            pass
+
+        if fill_color != "black" or back_color != "white":
+            if back_color == "transparent":
                 mode = "RGBA"
                 back_color = None
             else:
@@ -30,8 +40,8 @@ class PilImage(qrcode.image.base.BaseImage):
         else:
             mode = "1"
             # L mode (1 mode) color = (r*299 + g*587 + b*114)//1000
-            if fill_color.lower() == "black": fill_color = 0
-            if back_color.lower() == "white": back_color = 255
+            if fill_color == "black": fill_color = 0
+            if back_color == "white": back_color = 255
 
         img = Image.new(mode, (self.pixel_size, self.pixel_size), back_color)
         self.fill_color = fill_color


### PR DESCRIPTION
At the moment the code assumes that color values will be strings. This limits the range of colors that can be used. Trying to pass an RGB tuple raises an exception on the string methods used. 

By performing the string methods earlier and catching and ignoring the exceptions, other  data structures can quietly pass through to Image.new() to be accepted if supported, or  to raise an exception.

Ideally, PilImage should be color type agnostic and convert all values to some common color type to make the code as flexible as possible.