### PR TITLE
Add tostring() method to SVG images.

### DIFF
--- a/qrcode/image/svg.py
+++ b/qrcode/image/svg.py
@@ -41,6 +41,9 @@ class SvgFragmentImage(qrcode.image.base.BaseImage):
         self.check_kind(kind=kind)
         self._write(stream)
 
+    def tostring(self):
+        return ET.tostring(self._img)
+
     def new_image(self, **kwargs):
         return self._svg()
 
@@ -139,6 +142,10 @@ class SvgPathImage(SvgImage):
             d=' '.join(subpaths),
             id="qr-path"
         )
+
+    def tostring(self):
+        self._img.append(self.make_path())
+        return super(SvgPathImage, self).tostring()
 
     def _write(self, stream):
         self._img.append(self.make_path())


### PR DESCRIPTION
SVGs are particularly useful to have in string format, which can be output directly into HTML etc.

It took me far to long to figure out how to do this, so hopefully this will save other people some time.


As a side note, the SVGPathImage in the _write() method (which I've based this code on), appends the path code to the image element. Wouldn't this mess up the image if the save() method is called twice? Edit: Seems to be a fix #137 