### PR TITLE
Replace inline style with SVG attributes.

### DIFF
--- a/qrcode/image/svg.py
+++ b/qrcode/image/svg.py
@@ -96,7 +96,8 @@ class SvgPathImage(SvgImage):
     between individual QR points).
     """
 
-    QR_PATH_STYLE = 'fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none'
+    QR_PATH_STYLE = {'fill': '#000000', 'fill-opacity': '1',
+                     'fill-rule': 'nonzero', 'stroke': 'none'}
 
     def __init__(self, *args, **kwargs):
         self._points = set()
@@ -135,9 +136,9 @@ class SvgPathImage(SvgImage):
 
         return ET.Element(
             ET.QName("path"),
-            style=self.QR_PATH_STYLE,
             d=' '.join(subpaths),
-            id="qr-path"
+            id="qr-path",
+            **self.QR_PATH_STYLE
         )
 
     def _write(self, stream):


### PR DESCRIPTION
This replaces the inline style attribute with SVG attributes.

The main reason is to avoid errors caused by strict CSPs in web pages (without 'unsafe-inline').