### PR TITLE
Add support for Python 3.7-3.9, drop EOL 2.7 and 3.4-3.5

### DIFF
--- a/qrcode/base.py
+++ b/qrcode/base.py
@@ -274,7 +274,7 @@ RS_BLOCK_TABLE = [
 
 def glog(n):
     if n < 1:  # pragma: no cover
-        raise ValueError("glog(%s)" % n)
+        raise ValueError(f"glog({n})")
     return LOG_TABLE[n]
 
 
@@ -286,7 +286,7 @@ class Polynomial:
 
     def __init__(self, num, shift):
         if not num:  # pragma: no cover
-            raise Exception("{}/{}".format(len(num), shift))
+            raise Exception(f"{len(num)}/{shift}")
 
         for offset in range(len(num)):
             if num[offset] != 0:

--- a/qrcode/base.py
+++ b/qrcode/base.py
@@ -282,11 +282,11 @@ def gexp(n):
     return EXP_TABLE[n % 255]
 
 
-class Polynomial(object):
+class Polynomial:
 
     def __init__(self, num, shift):
         if not num:  # pragma: no cover
-            raise Exception("%s/%s" % (len(num), shift))
+            raise Exception("{}/{}".format(len(num), shift))
 
         for offset in range(len(num)):
             if num[offset] != 0:
@@ -331,7 +331,7 @@ class Polynomial(object):
         return Polynomial(num, 0) % other
 
 
-class RSBlock(object):
+class RSBlock:
 
     def __init__(self, total_count, data_count):
         self.total_count = total_count

--- a/qrcode/console_scripts.py
+++ b/qrcode/console_scripts.py
@@ -39,7 +39,7 @@ def main(args=None):
     parser.add_option(
         "--factory", help="Full python path to the image factory class to "
         "create the image with. You can use the following shortcuts to the "
-        "built-in image factory classes: {0}.".format(
+        "built-in image factory classes: {}.".format(
             ", ".join(sorted(default_factories.keys()))))
     parser.add_option(
         "--optimize", type=int, help="Optimize the data by looking for chunks "

--- a/qrcode/image/base.py
+++ b/qrcode/image/base.py
@@ -60,5 +60,5 @@ class BaseImage:
                 allowed = kind in self.allowed_kinds
         if not allowed:
             raise ValueError(
-                "Cannot set {} type to {}".format(type(self).__name__, kind))
+                f"Cannot set {type(self).__name__} type to {kind}")
         return kind

--- a/qrcode/image/base.py
+++ b/qrcode/image/base.py
@@ -1,6 +1,6 @@
 import abc
 
-class BaseImage(object):
+class BaseImage:
     """
     Base QRCode image output class.
     """
@@ -60,5 +60,5 @@ class BaseImage(object):
                 allowed = kind in self.allowed_kinds
         if not allowed:
             raise ValueError(
-                "Cannot set %s type to %s" % (type(self).__name__, kind))
+                "Cannot set {} type to {}".format(type(self).__name__, kind))
         return kind

--- a/qrcode/image/pil.py
+++ b/qrcode/image/pil.py
@@ -1,5 +1,4 @@
 # Needed on case-insensitive filesystems
-from __future__ import absolute_import
 
 # Try to import PIL in either of the two ways it can be installed.
 try:

--- a/qrcode/image/pure.py
+++ b/qrcode/image/pure.py
@@ -24,7 +24,7 @@ class PymagingImage(qrcode.image.base.BaseImage):
         registry._populate()
         registry.register(PNG)
 
-        super(PymagingImage, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def new_image(self, **kwargs):
         return Image.new(RGB, self.pixel_size, self.pixel_size, White)
@@ -45,5 +45,5 @@ class PymagingImage(qrcode.image.base.BaseImage):
         """
         if transform is None:
             transform = lambda x: x.lower()
-        return super(PymagingImage, self).check_kind(
+        return super().check_kind(
             kind, transform=transform, **kwargs)

--- a/qrcode/image/svg.py
+++ b/qrcode/image/svg.py
@@ -1,6 +1,4 @@
 from decimal import Decimal
-# On Python 2.6 must install lxml since the older xml.etree.ElementTree
-# version can not be used to create SVG images.
 try:
     import lxml.etree as ET
 except ImportError:

--- a/qrcode/image/svg.py
+++ b/qrcode/image/svg.py
@@ -19,7 +19,7 @@ class SvgFragmentImage(qrcode.image.base.BaseImage):
 
     def __init__(self, *args, **kwargs):
         ET.register_namespace("svg", self._SVG_namespace)
-        super(SvgFragmentImage, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         # Save the unit size, for example the default box_size of 10 is '1mm'.
         self.unit_size = self.units(self.box_size)
 
@@ -71,7 +71,7 @@ class SvgImage(SvgFragmentImage):
     background = None
 
     def _svg(self, tag='svg', **kwargs):
-        svg = super(SvgImage, self)._svg(tag=tag, **kwargs)
+        svg = super()._svg(tag=tag, **kwargs)
         svg.set("xmlns", self._SVG_namespace)
         if self.background:
             svg.append(
@@ -81,7 +81,7 @@ class SvgImage(SvgFragmentImage):
         return svg
 
     def _rect(self, row, col):
-        return super(SvgImage, self)._rect(row, col, tag="rect")
+        return super()._rect(row, col, tag="rect")
 
     def _write(self, stream):
         ET.ElementTree(self._img).write(stream, encoding="UTF-8",
@@ -98,13 +98,13 @@ class SvgPathImage(SvgImage):
 
     def __init__(self, *args, **kwargs):
         self._points = set()
-        super(SvgPathImage, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _svg(self, viewBox=None, **kwargs):
         if viewBox is None:
             dimension = self.units(self.pixel_size, text=False)
-            viewBox = '0 0 %(d)s %(d)s' % {'d': dimension}
-        return super(SvgPathImage, self)._svg(viewBox=viewBox, **kwargs)
+            viewBox = '0 0 {d} {d}'.format(d=dimension)
+        return super()._svg(viewBox=viewBox, **kwargs)
 
     def drawrect(self, row, col):
         # (x, y)
@@ -140,7 +140,7 @@ class SvgPathImage(SvgImage):
 
     def _write(self, stream):
         self._img.append(self.make_path())
-        super(SvgPathImage, self)._write(stream)
+        super()._write(stream)
 
 
 class SvgFillImage(SvgImage):

--- a/qrcode/main.py
+++ b/qrcode/main.py
@@ -14,7 +14,7 @@ def make(data=None, **kwargs):
 def _check_box_size(size):
     if int(size) <= 0:
         raise ValueError(
-            "Invalid box size (was %s, expected larger than 0)" % size)
+            f"Invalid box size (was {size}, expected larger than 0)")
 
 
 def _check_mask_pattern(mask_pattern):
@@ -22,10 +22,10 @@ def _check_mask_pattern(mask_pattern):
         return
     if not isinstance(mask_pattern, int):
         raise TypeError(
-            "Invalid mask pattern (was %s, expected int)" % type(mask_pattern))
+            f"Invalid mask pattern (was {type(mask_pattern)}, expected int)")
     if mask_pattern < 0 or mask_pattern > 7:
         raise ValueError(
-            "Mask pattern should be in range(8) (got %s)" % mask_pattern)
+            f"Mask pattern should be in range(8) (got {mask_pattern})")
 
 
 class QRCode:

--- a/qrcode/main.py
+++ b/qrcode/main.py
@@ -29,7 +29,7 @@ def _check_mask_pattern(mask_pattern):
             "Mask pattern should be in range(8) (got %s)" % mask_pattern)
 
 
-class QRCode(object):
+class QRCode:
 
     def __init__(self, version=None,
                  error_correction=constants.ERROR_CORRECT_M,
@@ -237,7 +237,7 @@ class QRCode(object):
             self.make()
 
         modcount = self.modules_count
-        codes = [six.int2byte(code).decode('cp437')
+        codes = [bytes((code,)).decode('cp437')
                  for code in (255, 223, 220, 219)]
         if tty:
             invert = True

--- a/qrcode/main.py
+++ b/qrcode/main.py
@@ -1,6 +1,7 @@
 from qrcode import constants, exceptions, util
 from qrcode.image.base import BaseImage
 
+import sys
 import six
 from bisect import bisect_left
 
@@ -227,15 +228,7 @@ class QRCode(object):
         :param invert: invert the ASCII characters (solid <-> transparent)
         """
         if out is None:
-            import sys
-            if sys.version_info < (2, 7):
-                # On Python versions 2.6 and earlier, stdout tries to encode
-                # strings using ASCII rather than stdout.encoding, so use this
-                # workaround.
-                import codecs
-                out = codecs.getwriter(sys.stdout.encoding)(sys.stdout)
-            else:
-                out = sys.stdout
+            out = sys.stdout
 
         if tty and not out.isatty():
             raise OSError("Not a tty")

--- a/qrcode/main.py
+++ b/qrcode/main.py
@@ -2,7 +2,6 @@ from qrcode import constants, exceptions, util
 from qrcode.image.base import BaseImage
 
 import sys
-import six
 from bisect import bisect_left
 
 
@@ -378,7 +377,7 @@ class QRCode:
 
         data_len = len(data)
 
-        for col in six.moves.xrange(self.modules_count - 1, 0, -2):
+        for col in range(self.modules_count - 1, 0, -2):
 
             if col <= 6:
                 col -= 1

--- a/qrcode/release.py
+++ b/qrcode/release.py
@@ -16,7 +16,7 @@ def update_manpage(data):
 
     base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     filename = os.path.join(base_dir, 'doc', 'qr.1')
-    with open(filename, 'r') as f:
+    with open(filename) as f:
         lines = f.readlines()
 
     changed = False

--- a/qrcode/tests/test_example.py
+++ b/qrcode/tests/test_example.py
@@ -1,11 +1,5 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest
+from unittest import mock
 
 from qrcode import run_example
 

--- a/qrcode/tests/test_qrcode.py
+++ b/qrcode/tests/test_qrcode.py
@@ -3,6 +3,8 @@ import six
 import sys
 import qrcode.util
 import qrcode.image.svg
+import unittest
+from unittest import mock
 
 try:
     import qrcode.image.pure
@@ -16,16 +18,6 @@ from qrcode.exceptions import DataOverflowError
 from qrcode.util import (
     QRData, MODE_NUMBER, MODE_ALPHA_NUM, MODE_8BIT_BYTE)
 from qrcode.tests.svg import SvgImageWhite
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 UNICODE_TEXT = u'\u03b1\u03b2\u03b3'
 

--- a/qrcode/tests/test_qrcode.py
+++ b/qrcode/tests/test_qrcode.py
@@ -19,7 +19,7 @@ from qrcode.util import (
     QRData, MODE_NUMBER, MODE_ALPHA_NUM, MODE_8BIT_BYTE)
 from qrcode.tests.svg import SvgImageWhite
 
-UNICODE_TEXT = u'\u03b1\u03b2\u03b3'
+UNICODE_TEXT = '\u03b1\u03b2\u03b3'
 
 
 class QRCodeTests(unittest.TestCase):
@@ -80,7 +80,7 @@ class QRCodeTests(unittest.TestCase):
 
     def test_mode_8bit(self):
         qr = qrcode.QRCode()
-        qr.add_data(u'abcABC' + UNICODE_TEXT, optimize=0)
+        qr.add_data('abcABC' + UNICODE_TEXT, optimize=0)
         qr.make()
         self.assertEqual(qr.version, 1)
         self.assertEqual(qr.data_list[0].mode, MODE_8BIT_BYTE)
@@ -190,8 +190,7 @@ class QRCodeTests(unittest.TestCase):
         from pymaging import Image as pymaging_Image
         self.assertIsInstance(img.get_image(), pymaging_Image)
         with warnings.catch_warnings():
-            if six.PY3:
-                warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter('ignore', DeprecationWarning)
             img.save(six.BytesIO())
 
     @unittest.skipIf(not pymaging_png, "Requires pymaging")
@@ -269,7 +268,7 @@ class QRCodeTests(unittest.TestCase):
         qr.print_ascii(out=f)
         printed = f.getvalue()
         f.close()
-        expected = u'\u2588\u2580\u2580\u2580\u2580\u2580\u2588'
+        expected = '\u2588\u2580\u2580\u2580\u2580\u2580\u2588'
         self.assertEqual(printed[:len(expected)], expected)
 
         f = six.StringIO()
@@ -278,8 +277,8 @@ class QRCodeTests(unittest.TestCase):
         printed = f.getvalue()
         f.close()
         expected = (
-            u'\x1b[48;5;232m\x1b[38;5;255m' +
-            u'\xa0\u2584\u2584\u2584\u2584\u2584\xa0')
+            '\x1b[48;5;232m\x1b[38;5;255m' +
+            '\xa0\u2584\u2584\u2584\u2584\u2584\xa0')
         self.assertEqual(printed[:len(expected)], expected)
 
     def test_print_tty_stdout(self):

--- a/qrcode/tests/test_qrcode.py
+++ b/qrcode/tests/test_qrcode.py
@@ -1,5 +1,5 @@
 import warnings
-import six
+import io
 import sys
 import qrcode.util
 import qrcode.image.svg
@@ -95,7 +95,7 @@ class QRCodeTests(unittest.TestCase):
         qr = qrcode.QRCode()
         qr.add_data(UNICODE_TEXT)
         img = qr.make_image()
-        img.save(six.BytesIO())
+        img.save(io.BytesIO())
         from qrcode.image.pil import Image as pil_Image
         self.assertIsInstance(img.get_image(), pil_Image.Image)
 
@@ -103,19 +103,19 @@ class QRCodeTests(unittest.TestCase):
         qr = qrcode.QRCode()
         qr.add_data(UNICODE_TEXT)
         img = qr.make_image(back_color='TransParent')
-        img.save(six.BytesIO())
+        img.save(io.BytesIO())
 
     def test_render_pil_with_red_background(self):
         qr = qrcode.QRCode()
         qr.add_data(UNICODE_TEXT)
         img = qr.make_image(back_color='red')
-        img.save(six.BytesIO())
+        img.save(io.BytesIO())
 
     def test_render_with_pattern(self):
         qr = qrcode.QRCode(mask_pattern=3)
         qr.add_data(UNICODE_TEXT)
         img = qr.make_image()
-        img.save(six.BytesIO())
+        img.save(io.BytesIO())
 
     def test_make_image_with_wrong_pattern(self):
         with self.assertRaises(TypeError):
@@ -162,25 +162,25 @@ class QRCodeTests(unittest.TestCase):
         qr = qrcode.QRCode()
         qr.add_data(UNICODE_TEXT)
         img = qr.make_image(image_factory=qrcode.image.svg.SvgImage)
-        img.save(six.BytesIO())
+        img.save(io.BytesIO())
 
     def test_render_svg_path(self):
         qr = qrcode.QRCode()
         qr.add_data(UNICODE_TEXT)
         img = qr.make_image(image_factory=qrcode.image.svg.SvgPathImage)
-        img.save(six.BytesIO())
+        img.save(io.BytesIO())
 
     def test_render_svg_fragment(self):
         qr = qrcode.QRCode()
         qr.add_data(UNICODE_TEXT)
         img = qr.make_image(image_factory=qrcode.image.svg.SvgFragmentImage)
-        img.save(six.BytesIO())
+        img.save(io.BytesIO())
 
     def test_render_svg_with_background(self):
         qr = qrcode.QRCode()
         qr.add_data(UNICODE_TEXT)
         img = qr.make_image(image_factory=SvgImageWhite)
-        img.save(six.BytesIO())
+        img.save(io.BytesIO())
 
     @unittest.skipIf(not pymaging_png, "Requires pymaging with PNG support")
     def test_render_pymaging_png(self):
@@ -191,7 +191,7 @@ class QRCodeTests(unittest.TestCase):
         self.assertIsInstance(img.get_image(), pymaging_Image)
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
-            img.save(six.BytesIO())
+            img.save(io.BytesIO())
 
     @unittest.skipIf(not pymaging_png, "Requires pymaging")
     def test_render_pymaging_png_bad_kind(self):
@@ -199,7 +199,7 @@ class QRCodeTests(unittest.TestCase):
         qr.add_data(UNICODE_TEXT)
         img = qr.make_image(image_factory=qrcode.image.pure.PymagingImage)
         with self.assertRaises(ValueError):
-            img.save(six.BytesIO(), kind='FISH')
+            img.save(io.BytesIO(), kind='FISH')
 
     def test_optimize(self):
         qr = qrcode.QRCode()
@@ -264,14 +264,14 @@ class QRCodeTests(unittest.TestCase):
 
     def test_print_ascii(self):
         qr = qrcode.QRCode(border=0)
-        f = six.StringIO()
+        f = io.StringIO()
         qr.print_ascii(out=f)
         printed = f.getvalue()
         f.close()
         expected = '\u2588\u2580\u2580\u2580\u2580\u2580\u2588'
         self.assertEqual(printed[:len(expected)], expected)
 
-        f = six.StringIO()
+        f = io.StringIO()
         f.isatty = lambda: True
         qr.print_ascii(out=f, tty=True)
         printed = f.getvalue()
@@ -290,7 +290,7 @@ class QRCodeTests(unittest.TestCase):
 
     def test_print_tty(self):
         qr = qrcode.QRCode()
-        f = six.StringIO()
+        f = io.StringIO()
         f.isatty = lambda: True
         qr.print_tty(out=f)
         printed = f.getvalue()

--- a/qrcode/tests/test_release.py
+++ b/qrcode/tests/test_release.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from qrcode.release import update_manpage
 
-OPEN = '{}.open'.format(builtins.__name__)
+OPEN = f'{builtins.__name__}.open'
 DATA = 'test\n.TH "date" "version" "description"\nthis'
 
 

--- a/qrcode/tests/test_release.py
+++ b/qrcode/tests/test_release.py
@@ -1,4 +1,3 @@
-import sys
 import re
 import builtins
 import datetime
@@ -11,9 +10,6 @@ OPEN = '{}.open'.format(builtins.__name__)
 DATA = 'test\n.TH "date" "version" "description"\nthis'
 
 
-@unittest.skipIf(
-    sys.version_info[0] == 3 and sys.version_info[1] < 6,
-    "mock_file not working on Python 3 when less than 3.6")
 class UpdateManpageTests(unittest.TestCase):
 
     @mock.patch(OPEN, new_callable=mock.mock_open, read_data='.TH invalid')

--- a/qrcode/tests/test_release.py
+++ b/qrcode/tests/test_release.py
@@ -2,10 +2,7 @@ import sys
 import re
 import datetime
 import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import six
 from qrcode.release import update_manpage

--- a/qrcode/tests/test_release.py
+++ b/qrcode/tests/test_release.py
@@ -1,13 +1,13 @@
 import sys
 import re
+import builtins
 import datetime
 import unittest
 from unittest import mock
 
-import six
 from qrcode.release import update_manpage
 
-OPEN = '{}.open'.format(six.moves.builtins.__name__)
+OPEN = '{}.open'.format(builtins.__name__)
 DATA = 'test\n.TH "date" "version" "description"\nthis'
 
 

--- a/qrcode/tests/test_script.py
+++ b/qrcode/tests/test_script.py
@@ -1,12 +1,6 @@
 import sys
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest
+from unittest import mock
 
 from qrcode.console_scripts import main
 
@@ -39,7 +33,6 @@ class ScriptTest(unittest.TestCase):
         self.assertTrue(stdin_buffer.read.called)
         mock_print_ascii.assert_called_with(tty=True)
 
-    @unittest.skipIf(sys.version_info[0] < 3, 'Python 3')
     @mock.patch('os.isatty', lambda *args: True)
     @mock.patch('qrcode.main.QRCode.print_ascii')
     def test_stdin_py3_unicodedecodeerror(self, mock_print_ascii):

--- a/qrcode/tests/test_util.py
+++ b/qrcode/tests/test_util.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from qrcode import util
 

--- a/qrcode/util.py
+++ b/qrcode/util.py
@@ -32,8 +32,8 @@ MODE_SIZE_LARGE = {
     MODE_KANJI: 12,
 }
 
-ALPHA_NUM = six.b('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:')
-RE_ALPHA_NUM = re.compile(six.b('^[') + re.escape(ALPHA_NUM) + six.b(r']*\Z'))
+ALPHA_NUM = b'0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:'
+RE_ALPHA_NUM = re.compile(b'^[' + re.escape(ALPHA_NUM) + br']*\Z')
 
 # The number of bits for numeric delimited data lengths.
 NUMBER_LENGTH = {3: 10, 2: 7, 1: 4}
@@ -348,14 +348,14 @@ def optimal_data_chunks(data, minimum=4):
     :param minimum: The minimum number of bytes in a row to split as a chunk.
     """
     data = to_bytestring(data)
-    num_pattern = six.b(r'\d')
-    alpha_pattern = six.b('[') + re.escape(ALPHA_NUM) + six.b(']')
+    num_pattern = br'\d'
+    alpha_pattern = b'[' + re.escape(ALPHA_NUM) + b']'
     if len(data) <= minimum:
-        num_pattern = re.compile(six.b('^') + num_pattern + six.b('+$'))
-        alpha_pattern = re.compile(six.b('^') + alpha_pattern + six.b('+$'))
+        num_pattern = re.compile(b'^' + num_pattern + b'+$')
+        alpha_pattern = re.compile(b'^' + alpha_pattern + b'+$')
     else:
         re_repeat = (
-            six.b('{') + six.text_type(minimum).encode('ascii') + six.b(',}'))
+            b'{' + str(minimum).encode('ascii') + b',}')
         num_pattern = re.compile(num_pattern + re_repeat)
         alpha_pattern = re.compile(alpha_pattern + re_repeat)
     num_bits = _optimal_split(data, num_pattern)
@@ -390,8 +390,8 @@ def to_bytestring(data):
     Convert data to a (utf-8 encoded) byte-string if it isn't a byte-string
     already.
     """
-    if not isinstance(data, six.binary_type):
-        data = six.text_type(data).encode('utf-8')
+    if not isinstance(data, bytes):
+        data = str(data).encode('utf-8')
     return data
 
 
@@ -406,7 +406,7 @@ def optimal_mode(data):
     return MODE_8BIT_BYTE
 
 
-class QRData(object):
+class QRData:
     """
     Data held in a QR compatible format.
 
@@ -430,7 +430,7 @@ class QRData(object):
             if check_data and mode < optimal_mode(data):  # pragma: no cover
                 raise ValueError(
                     "Provided data can not be represented in mode "
-                    "{0}".format(mode))
+                    "{}".format(mode))
 
         self.data = data
 
@@ -453,12 +453,9 @@ class QRData(object):
                 else:
                     buffer.put(ALPHA_NUM.find(chars), 6)
         else:
-            if six.PY3:
-                # Iterating a bytestring in Python 3 returns an integer,
-                # no need to ord().
-                data = self.data
-            else:
-                data = [ord(c) for c in self.data]
+            # Iterating a bytestring in Python 3 returns an integer,
+            # no need to ord().
+            data = self.data
             for c in data:
                 buffer.put(c, 8)
 
@@ -466,7 +463,7 @@ class QRData(object):
         return repr(self.data)
 
 
-class BitBuffer(object):
+class BitBuffer:
 
     def __init__(self):
         self.buffer = []

--- a/qrcode/util.py
+++ b/qrcode/util.py
@@ -1,9 +1,6 @@
 import re
 import math
 
-import six
-from six.moves import xrange
-
 from qrcode import base, exceptions, LUT
 
 # QR encoding modes.
@@ -96,8 +93,8 @@ PAD1 = 0x11
 _data_count = lambda block: block.data_count
 BIT_LIMIT_TABLE = [
     [0] + [8*sum(map(_data_count, base.rs_blocks(version, error_correction)))
-           for version in xrange(1, 41)]
-    for error_correction in xrange(4)
+           for version in range(1, 41)]
+    for error_correction in range(4)
 ]
 
 
@@ -192,7 +189,7 @@ def lost_point(modules):
 def _lost_point_level1(modules, modules_count):
     lost_point = 0
 
-    modules_range = xrange(modules_count)
+    modules_range = range(modules_count)
     container = [0] * (modules_count + 1)
 
     for row in modules_range:
@@ -225,7 +222,7 @@ def _lost_point_level1(modules, modules_count):
             container[length] += 1
 
     lost_point += sum(container[each_length] * (each_length - 2)
-        for each_length in xrange(5, modules_count + 1))
+        for each_length in range(5, modules_count + 1))
 
     return lost_point
 
@@ -233,7 +230,7 @@ def _lost_point_level1(modules, modules_count):
 def _lost_point_level2(modules, modules_count):
     lost_point = 0
 
-    modules_range = xrange(modules_count - 1)
+    modules_range = range(modules_count - 1)
     for row in modules_range:
         this_row = modules[row]
         next_row = modules[row + 1]
@@ -262,8 +259,8 @@ def _lost_point_level3(modules, modules_count):
     # row/column, preceded or followed by light area 4 modules wide. From ISOIEC.
     # pattern1:     10111010000
     # pattern2: 00001011101
-    modules_range = xrange(modules_count)
-    modules_range_short = xrange(modules_count-10)
+    modules_range = range(modules_count)
+    modules_range_short = range(modules_count-10)
     lost_point = 0
 
     for row in modules_range:
@@ -439,12 +436,12 @@ class QRData:
 
     def write(self, buffer):
         if self.mode == MODE_NUMBER:
-            for i in xrange(0, len(self.data), 3):
+            for i in range(0, len(self.data), 3):
                 chars = self.data[i:i + 3]
                 bit_length = NUMBER_LENGTH[len(chars)]
                 buffer.put(int(chars), bit_length)
         elif self.mode == MODE_ALPHA_NUM:
-            for i in xrange(0, len(self.data), 2):
+            for i in range(0, len(self.data), 2):
                 chars = self.data[i:i + 2]
                 if len(chars) > 1:
                     buffer.put(

--- a/qrcode/util.py
+++ b/qrcode/util.py
@@ -160,7 +160,7 @@ def mode_sizes_for_version(version):
 def length_in_bits(mode, version):
     if mode not in (
             MODE_NUMBER, MODE_ALPHA_NUM, MODE_8BIT_BYTE, MODE_KANJI):
-        raise TypeError("Invalid mode (%s)" % mode)  # pragma: no cover
+        raise TypeError(f"Invalid mode ({mode})")  # pragma: no cover
 
     check_version(version)
 
@@ -170,7 +170,7 @@ def length_in_bits(mode, version):
 def check_version(version):
     if version < 1 or version > 40:
         raise ValueError(
-            "Invalid version (was %s, expected 1 to 40)" % version)
+            f"Invalid version (was {version}, expected 1 to 40)")
 
 
 def lost_point(modules):
@@ -423,11 +423,10 @@ class QRData:
         else:
             self.mode = mode
             if mode not in (MODE_NUMBER, MODE_ALPHA_NUM, MODE_8BIT_BYTE):
-                raise TypeError("Invalid mode (%s)" % mode)  # pragma: no cover
+                raise TypeError(f"Invalid mode ({mode})")  # pragma: no cover
             if check_data and mode < optimal_mode(data):  # pragma: no cover
                 raise ValueError(
-                    "Provided data can not be represented in mode "
-                    "{}".format(mode))
+                    f"Provided data can not be represented in mode {mode}")
 
         self.data = data
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,10 @@ classifiers =
     Intended Audience :: Developers
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3 :: Only
     Topic :: Multimedia :: Graphics
     Topic :: Software Development :: Libraries :: Python Modules
@@ -28,7 +29,7 @@ include_package_data = True
 packages = find:
 install_requires =
     colorama;platform_system=="Windows"
-python_requires = >= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, != 3.3.*
+python_requires = >= 3.6
 
 [options.extras_require]
 maintainer =

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ include_package_data = True
 packages = find:
 install_requires =
     colorama;platform_system=="Windows"
+python_requires = >= 2.7, != 3.0.*, != 3.1.*, != 3.2.*, != 3.3.*
 
 [options.extras_require]
 maintainer =

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,11 @@ classifiers =
     Operating System :: OS Independent
     Intended Audience :: Developers
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3 :: Only
     Topic :: Multimedia :: Graphics
     Topic :: Software Development :: Libraries :: Python Modules
 
@@ -35,11 +36,9 @@ maintainer =
 dev =
     tox
     pytest
-    mock;python_version<"3"
 test =
     pytest
     pytest-cov
-    mock;python_version<"3"
 pil =
     pillow
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    six
     colorama;platform_system=="Windows"
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,10 +46,6 @@ pil =
 console-scripts =
     qr = qrcode.console_scripts:main
 
-[bdist_wheel]
-# Works in both Python 2 and Python 3
-universal = 1
-
 [flake8]
 exclude =
     .tox

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 distribute = False
 envlist =
     coverage_setup
-    py{34,35,36,37}
+    py{36,37,38,39}
     readme
     coverage_report
 skip_missing_interpreters = True

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 distribute = False
 envlist =
     coverage_setup
-    py{27,34,35,36,37}
+    py{34,35,36,37}
     readme
     coverage_report
 skip_missing_interpreters = True


### PR DESCRIPTION
Fixes https://github.com/lincolnloop/python-qrcode/issues/166.

Builds on https://github.com/lincolnloop/python-qrcode/pull/208.

```console
$ tox -e py36,py37,py38,py39
py36 develop-inst-noop: /private/tmp/python-qrcode
py36 installed: attrs==20.2.0,coverage==5.3,importlib-metadata==2.0.0,iniconfig==1.0.1,packaging==20.4,Pillow==7.2.0,pluggy==0.13.1,py==1.9.0,pymaging @ git+git://github.com/ojii/pymaging.git@596a08fce5664e58d6e8c96847393fbe987783f2,pymaging-png @ git+git://github.com/ojii/pymaging-png.git@83d85c44e4b2342818e6c068065e031a9f81bb9f,pyparsing==2.4.7,pytest==6.1.1,pytest-cov==2.10.1,-e git+https://github.com/hugovk/python-qrcode@a53f4beb3536307c3d6a32d71fb6258d8b1430d4#egg=qrcode,six==1.15.0,toml==0.10.1,zipp==3.3.0
py36 run-test-pre: PYTHONHASHSEED='2404440001'
py36 run-test: commands[0] | pytest --cov --cov-append --cov-report=
=================================================== test session starts ===================================================
platform darwin -- Python 3.6.10, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
cachedir: .tox/py36/.pytest_cache
rootdir: /private/tmp/python-qrcode, configfile: setup.cfg
plugins: cov-2.10.1
collected 52 items

qrcode/tests/test_example.py .                                                                                      [  1%]
qrcode/tests/test_qrcode.py .......................................                                                 [ 76%]
qrcode/tests/test_release.py ....                                                                                   [ 84%]
qrcode/tests/test_script.py .......                                                                                 [ 98%]
qrcode/tests/test_util.py .                                                                                         [100%]

==================================================== warnings summary =====================================================
qrcode/tests/test_release.py::UpdateManpageTests::test_change
  /Users/hugo/.pyenv/versions/3.6.10/lib/python3.6/re.py:212: FutureWarning: split() requires a non-empty pattern match.
    return _compile(pattern, flags).split(string, maxsplit)

-- Docs: https://docs.pytest.org/en/stable/warnings.html


============================================== 52 passed, 1 warning in 3.74s ==============================================
py37 develop-inst-noop: /private/tmp/python-qrcode
py37 installed: attrs==20.2.0,coverage==5.3,importlib-metadata==2.0.0,iniconfig==1.0.1,packaging==20.4,Pillow==7.2.0,pluggy==0.13.1,py==1.9.0,pymaging @ git+git://github.com/ojii/pymaging.git@596a08fce5664e58d6e8c96847393fbe987783f2,pymaging-png @ git+git://github.com/ojii/pymaging-png.git@83d85c44e4b2342818e6c068065e031a9f81bb9f,pyparsing==2.4.7,pytest==6.1.1,pytest-cov==2.10.1,-e git+https://github.com/hugovk/python-qrcode@a53f4beb3536307c3d6a32d71fb6258d8b1430d4#egg=qrcode,six==1.15.0,toml==0.10.1,zipp==3.3.0
py37 run-test-pre: PYTHONHASHSEED='2404440001'
py37 run-test: commands[0] | pytest --cov --cov-append --cov-report=
=================================================== test session starts ===================================================
platform darwin -- Python 3.7.7, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
cachedir: .tox/py37/.pytest_cache
rootdir: /private/tmp/python-qrcode, configfile: setup.cfg
plugins: cov-2.10.1
collected 52 items

qrcode/tests/test_example.py .                                                                                      [  1%]
qrcode/tests/test_qrcode.py .......................................                                                 [ 76%]
qrcode/tests/test_release.py ....                                                                                   [ 84%]
qrcode/tests/test_script.py .......                                                                                 [ 98%]
qrcode/tests/test_util.py .                                                                                         [100%]



=================================================== 52 passed in 3.69s ====================================================
py38 develop-inst-noop: /private/tmp/python-qrcode
py38 installed: attrs==20.2.0,coverage==5.3,iniconfig==1.0.1,packaging==20.4,Pillow==7.2.0,pluggy==0.13.1,py==1.9.0,pymaging @ git+git://github.com/ojii/pymaging.git@596a08fce5664e58d6e8c96847393fbe987783f2,pymaging-png @ git+git://github.com/ojii/pymaging-png.git@83d85c44e4b2342818e6c068065e031a9f81bb9f,pyparsing==2.4.7,pytest==6.1.1,pytest-cov==2.10.1,-e git+https://github.com/hugovk/python-qrcode@a53f4beb3536307c3d6a32d71fb6258d8b1430d4#egg=qrcode,six==1.15.0,toml==0.10.1
py38 run-test-pre: PYTHONHASHSEED='2404440001'
py38 run-test: commands[0] | pytest --cov --cov-append --cov-report=
=================================================== test session starts ===================================================
platform darwin -- Python 3.8.6, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
cachedir: .tox/py38/.pytest_cache
rootdir: /private/tmp/python-qrcode, configfile: setup.cfg
plugins: cov-2.10.1
collected 52 items

qrcode/tests/test_example.py .                                                                                      [  1%]
qrcode/tests/test_qrcode.py .......................................                                                 [ 76%]
qrcode/tests/test_release.py ....                                                                                   [ 84%]
qrcode/tests/test_script.py .......                                                                                 [ 98%]
qrcode/tests/test_util.py .                                                                                         [100%]



=================================================== 52 passed in 3.66s ====================================================
py39 develop-inst-noop: /private/tmp/python-qrcode
py39 installed: pymaging @ git+git://github.com/ojii/pymaging.git@596a08fce5664e58d6e8c96847393fbe987783f2,pymaging-png @ git+git://github.com/ojii/pymaging-png.git@83d85c44e4b2342818e6c068065e031a9f81bb9f,six==1.15.0
py39 run-test-pre: PYTHONHASHSEED='2404440001'
py39 run-test: commands[0] | pytest --cov --cov-append --cov-report=
WARNING: test command found but not installed in testenv
  cmd: /Users/hugo/.pyenv/shims/pytest
  env: /private/tmp/python-qrcode/.tox/py39
Maybe you forgot to specify a dependency? See also the allowlist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
=================================================== test session starts ===================================================
platform darwin -- Python 3.9.0, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
cachedir: .tox/py39/.pytest_cache
rootdir: /private/tmp/python-qrcode, configfile: setup.cfg
plugins: xdist-2.1.0, cov-2.10.1, forked-1.3.0
collected 52 items

qrcode/tests/test_example.py .                                                                                      [  1%]
qrcode/tests/test_qrcode.py ...............................ss......                                                 [ 76%]
qrcode/tests/test_release.py ....                                                                                   [ 84%]
qrcode/tests/test_script.py .......                                                                                 [ 98%]
qrcode/tests/test_util.py .                                                                                         [100%]



============================================== 50 passed, 2 skipped in 3.24s ==============================================
_________________________________________________________ summary _________________________________________________________
  py36: commands succeeded
  py37: commands succeeded
  py38: commands succeeded
  py39: commands succeeded
  congratulations :)
```