### PR TITLE
Use underscore keys to fix setuptools warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ pil =
     pillow
 
 [options.entry_points]
-console-scripts =
+console_scripts =
     qr = qrcode.console_scripts:main
 
 [flake8]


### PR DESCRIPTION
Fix the following setuptools warning:

    /usr/lib/python3.10/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'console-scripts' will not be supported in future versions. Please use the underscore name 'console_scripts' instead