### PR TITLE
concentric squares for plotters

### DIFF
--- a/qrcode/image/svg.py
+++ b/qrcode/image/svg.py
@@ -91,6 +91,7 @@ class SvgImage(SvgFragmentImage):
                                         xml_declaration=True)
 
 
+
 class SvgPathImage(SvgImage):
     """
     SVG image builder with one single <path> element (removes white spaces
@@ -150,6 +151,46 @@ class SvgPathImage(SvgImage):
     def _write(self, stream):
         self._img.append(self.make_path())
         super()._write(stream)
+
+
+
+class SvgForPlotters(SvgPathImage):
+    """
+    Draws the modules as concentric squares ; this is made necessary for tools such as plotters
+    and laser cutters which otherwise only draw the outline of the module.
+
+    The stroke_width parameter determines how many concentric squares are drawn.
+    """
+    QR_PATH_STYLE = {'fill': 'none', 'fill-rule': 'nonzero', 
+                     'stroke': '#000000'}
+
+    def __init__(self, *args, **kwargs):
+        self.stroke_width = kwargs.pop('stroke_width', 0.2)
+        self.QR_PATH_STYLE['stroke-width'] = f'{self.stroke_width}'
+        super().__init__(*args, **kwargs)
+
+
+    def _generate_subpaths(self):
+        """Generates individual QR points as subpaths"""
+
+        rect_size = self.units(self.box_size, text=False)
+
+        for point in self._points:
+            x_base = self.units(
+                (point[0]+self.border)*self.box_size, text=False)
+            y_base = self.units(
+                (point[1]+self.border)*self.box_size, text=False)
+
+            for x in range(1,int(float(rect_size)/self.stroke_width/2)+1):
+                if x%2==1:
+                    offset = x*self.stroke_width
+                    yield (
+                        'M %(x0)s %(y0)s L %(x0)s %(y1)s L %(x1)s %(y1)s L %(x1)s '
+                        '%(y0)s z' % dict(
+                            x0=float(x_base)+offset, y0=float(y_base)+offset,
+                            x1=float(x_base+rect_size)-offset, y1=float(y_base+rect_size)-offset,
+                      ))
+
 
 
 class SvgFillImage(SvgImage):

--- a/testSvgForPlotters.py
+++ b/testSvgForPlotters.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python
+import qrcode
+from qrcode.image.svg import SvgForPlotters
+
+box_size = 10
+border = 4
+
+qr = qrcode.QRCode(error_correction=qrcode.constants.ERROR_CORRECT_H, box_size=box_size, border=border)
+qr.add_data(b"Engrave this code on steel, let it rust and then only use sandpaper to clean the surface before applying a transparent protective coating.")
+
+img_1 = qr.make_image(image_factory=SvgForPlotters, stroke_width=.02)
+img_1.save('out.svg')


### PR DESCRIPTION
Plotters and devices such as laser cutters are usually unable to
automagically fill surfaces ; for this reason it is necessary to draw
(for example) concentric squares for each module, so that the toolhead
path effectively fills the modules.