### PR TITLE
Allow fine-tuning of SVG output by forwarding keyword arguments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,6 +137,26 @@ background of the SVG with white::
     qrcode.image.svg.SvgFillImage
     qrcode.image.svg.SvgPathFillImage
 
+The ``QRCode.make_image()`` method forwards additional keyword arguments to
+the underlying ElementTree XML library. This helps to finetune the root element
+of the resulting SVG:
+
+.. code:: python
+
+    import qrcode
+    qr = qrcode.QRCode(image_factory=qrcode.image.svg.SvgPathImage)
+    qr.add_data('Some data')
+    qr.make(fit=True)
+
+    img = qr.make_image(attrib={'class': 'some-css-class'})
+
+You can convert the SVG image into to strings using the ``to_string()`` method.
+Additional keyword arguments are forwarded to ElementTrees ``tostring()``:
+
+.. code:: python
+
+    img.to_string(encoding='unicode')
+
 
 Pure Python PNG
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -150,7 +150,7 @@ of the resulting SVG:
 
     img = qr.make_image(attrib={'class': 'some-css-class'})
 
-You can convert the SVG image into to strings using the ``to_string()`` method.
+You can convert the SVG image into strings using the ``to_string()`` method.
 Additional keyword arguments are forwarded to ElementTrees ``tostring()``:
 
 .. code:: python

--- a/qrcode/image/svg.py
+++ b/qrcode/image/svg.py
@@ -39,11 +39,11 @@ class SvgFragmentImage(qrcode.image.base.BaseImage):
         self.check_kind(kind=kind)
         self._write(stream)
 
-    def to_string(self):
-        return ET.tostring(self._img)
+    def to_string(self, **kwargs):
+        return ET.tostring(self._img, **kwargs)
 
     def new_image(self, **kwargs):
-        return self._svg()
+        return self._svg(**kwargs)
 
     def _svg(self, tag=None, version='1.1', **kwargs):
         if tag is None:
@@ -142,10 +142,10 @@ class SvgPathImage(SvgImage):
             **self.QR_PATH_STYLE
         )
 
-    def to_string(self):
+    def to_string(self, **kwargs):
         img = self._img.__copy__()
         img.append(self.make_path())
-        return ET.tostring(img)
+        return ET.tostring(img, **kwargs)
 
     def _write(self, stream):
         self._img.append(self.make_path())


### PR DESCRIPTION
Forwarding the `kwargs` in `SvgFragmentImage.new_image()` allows additional fine-tuning of the resulting SVG node. Similarly, adding `kwargs` to the `to_string()` method helps to adjust things like the string encoding:

```
qr = qrcode.QRCode(image_factory=qrcode.image.svg.SvgPathImage)
svg_str = qr.make_image(attrib={'class': 'some-css-class'}).to_string(encoding='unicode')
```

Both features are mentioned in the README. Let me know what you think...