### PR TITLE
docs: Fix a few typos

### DIFF
--- a/PACKAGING.rst
+++ b/PACKAGING.rst
@@ -5,6 +5,6 @@ Make sure maintainer dependencies are installed::
 
     pip install -e .[maintainer,dev]
 
-Run release commad and follow prompt instuctions::
+Run release command and follow prompt instructions::
 
     fullrelease


### PR DESCRIPTION
There are small typos in:
- PACKAGING.rst

Fixes:
- Should read `instructions` rather than `instuctions`.
- Should read `command` rather than `commad`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md