### PR TITLE
Change constants usage to remove pillow future updates warnings

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/qrcode/image/styledpil.py
+++ b/qrcode/image/styledpil.py
@@ -30,7 +30,7 @@ class StyledPilImage(qrcode.image.base.BaseImageWithDrawer):
     ensure that the QR code is still legible after the image has been placed
     there; Q or H level error correction levels are recommended to maintain
     data integrity A resampling filter can be specified (defaulting to
-    PIL.Image.LANCZOS) for resizing; see PIL.Image.resize() for possible
+    PIL.Image.Resampling.LANCZOS) for resizing; see PIL.Image.resize() for possible
     options for this parameter.
     """
 
@@ -45,7 +45,7 @@ class StyledPilImage(qrcode.image.base.BaseImageWithDrawer):
         embeded_image_path = kwargs.get("embeded_image_path", None)
         self.embeded_image = kwargs.get("embeded_image", None)
         self.embeded_image_resample = kwargs.get(
-            "embeded_image_resample", Image.LANCZOS
+            "embeded_image_resample", Image.Resampling.LANCZOS
         )
         if not self.embeded_image and embeded_image_path:
             self.embeded_image = Image.open(embeded_image_path)

--- a/qrcode/image/styles/moduledrawers/pil.py
+++ b/qrcode/image/styles/moduledrawers/pil.py
@@ -87,7 +87,7 @@ class CircleModuleDrawer(StyledPilQRModuleDrawer):
         ImageDraw.Draw(self.circle).ellipse(
             (0, 0, fake_size, fake_size), fill=self.img.paint_color
         )
-        self.circle = self.circle.resize((box_size, box_size), Image.LANCZOS)
+        self.circle = self.circle.resize((box_size, box_size), Image.Resampling.LANCZOS)
 
     def drawrect(self, box, is_active: bool):
         if is_active:
@@ -133,11 +133,11 @@ class RoundedModuleDrawer(StyledPilQRModuleDrawer):
         base_draw.rectangle((radius, 0, fake_width, fake_width), fill=front_color)
         base_draw.rectangle((0, radius, fake_width, fake_width), fill=front_color)
         self.NW_ROUND = base.resize(
-            (self.corner_width, self.corner_width), Image.LANCZOS
+            (self.corner_width, self.corner_width), Image.Resampling.LANCZOS
         )
-        self.SW_ROUND = self.NW_ROUND.transpose(Image.FLIP_TOP_BOTTOM)
-        self.SE_ROUND = self.NW_ROUND.transpose(Image.ROTATE_180)
-        self.NE_ROUND = self.NW_ROUND.transpose(Image.FLIP_LEFT_RIGHT)
+        self.SW_ROUND = self.NW_ROUND.transpose(Image.Transpose.FLIP_TOP_BOTTOM)
+        self.SE_ROUND = self.NW_ROUND.transpose(Image.Transpose.ROTATE_180)
+        self.NE_ROUND = self.NW_ROUND.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
 
     def drawrect(self, box: List[List[int]], is_active: "ActiveWithNeighbors"):
         if not is_active:
@@ -196,8 +196,8 @@ class VerticalBarsDrawer(StyledPilQRModuleDrawer):
         base_draw = ImageDraw.Draw(base)
         base_draw.ellipse((0, 0, fake_width, fake_height * 2), fill=front_color)
 
-        self.ROUND_TOP = base.resize((shrunken_width, height), Image.LANCZOS)
-        self.ROUND_BOTTOM = self.ROUND_TOP.transpose(Image.FLIP_TOP_BOTTOM)
+        self.ROUND_TOP = base.resize((shrunken_width, height), Image.Resampling.LANCZOS)
+        self.ROUND_BOTTOM = self.ROUND_TOP.transpose(Image.Transpose.FLIP_TOP_BOTTOM)
 
     def drawrect(self, box, is_active: "ActiveWithNeighbors"):
         if is_active:
@@ -249,8 +249,8 @@ class HorizontalBarsDrawer(StyledPilQRModuleDrawer):
         base_draw = ImageDraw.Draw(base)
         base_draw.ellipse((0, 0, fake_width * 2, fake_height), fill=front_color)
 
-        self.ROUND_LEFT = base.resize((width, shrunken_height), Image.LANCZOS)
-        self.ROUND_RIGHT = self.ROUND_LEFT.transpose(Image.FLIP_LEFT_RIGHT)
+        self.ROUND_LEFT = base.resize((width, shrunken_height), Image.Resampling.LANCZOS)
+        self.ROUND_RIGHT = self.ROUND_LEFT.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
 
     def drawrect(self, box, is_active: "ActiveWithNeighbors"):
         if is_active:

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,14 +45,14 @@ test =
     coverage
     pytest
 pil =
-    pillow
+    pillow>=9.1.0
 all =
     zest.releaser[recommended]
     tox
     pytest
     pytest
     pytest-cov
-    pillow
+    pillow>=9.1.0
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     Intended Audience :: Developers
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -32,7 +31,7 @@ install_requires =
     colorama;platform_system=="Windows"
     typing_extensions
     pypng
-python_requires = >= 3.6
+python_requires = >= 3.7
 
 [options.extras_require]
 maintainer =

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ skip_missing_interpreters = True
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39, readme, nopil


### PR DESCRIPTION
Change constants usage to fix the deprecation warnings for PIL >= 10

This is a simple change to use the constants from the Enum defined in the `PIL.Image` module to remove the deprecation messages from pillow:

```text
.../qrcode/image/styledpil.py:49: DeprecationWarning: LANCZOS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.
    self.embeded_image_resample = kwargs.get("embeded_image_resample", Image.LANCZOS)

.../qrcode/image/styles/moduledrawers.py:128: DeprecationWarning: LANCZOS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.
    self.NW_ROUND = base.resize((self.corner_width, self.corner_width), Image.LANCZOS)

.../qrcode/image/styles/moduledrawers.py:129: DeprecationWarning: FLIP_TOP_BOTTOM is deprecated and will be removed in Pillow 10 (2023-07-01). Use Transpose.FLIP_TOP_BOTTOM instead.
    self.SW_ROUND = self.NW_ROUND.transpose(Image.FLIP_TOP_BOTTOM)

.../qrcode/image/styles/moduledrawers.py:130: DeprecationWarning: ROTATE_180 is deprecated and will be removed in Pillow 10 (2023-07-01). Use Transpose.ROTATE_180 instead.
    self.SE_ROUND = self.NW_ROUND.transpose(Image.ROTATE_180)

.../qrcode/image/styles/moduledrawers.py:131: DeprecationWarning: FLIP_LEFT_RIGHT is deprecated and will be removed in Pillow 10 (2023-07-01). Use Transpose.FLIP_LEFT_RIGHT instead.
    self.NE_ROUND = self.NW_ROUND.transpose(Image.FLIP_LEFT_RIGHT)
```
