### PR TITLE
Use typing_extensions only when needed

### DIFF
--- a/qrcode/image/svg.py
+++ b/qrcode/image/svg.py
@@ -2,7 +2,11 @@ import decimal
 from decimal import Decimal
 from typing import List, Optional, Type, Union, overload
 
-from typing_extensions import Literal
+try:
+    # Python 3.8+
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 import qrcode.image.base
 from qrcode.compat.etree import ET

--- a/qrcode/main.py
+++ b/qrcode/main.py
@@ -12,7 +12,11 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Literal
+try:
+    # Python 3.8+
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from qrcode import constants, exceptions, util
 from qrcode.image.base import BaseImage

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ include_package_data = True
 packages = find:
 install_requires =
     colorama;platform_system=="Windows"
-    typing_extensions
+    typing_extensions;python_version<"3.8.0"
     pypng
 python_requires = >= 3.7
 


### PR DESCRIPTION
Literal has been added with PEP 586 to Python 3.8