### PR TITLE
correct call on mock_file().write

### DIFF
--- a/qrcode/tests/test_release.py
+++ b/qrcode/tests/test_release.py
@@ -37,4 +37,4 @@ class UpdateManpageTests(unittest.TestCase):
             .replace("version", "3.11")
             .replace("date", datetime.datetime.now().strftime("%-d %b %Y"))
         )
-        mock_file().write.has_calls([mock.call(line) for line in expected])
+        mock_file().write.assert_has_calls([mock.call(line) for line in expected if line])


### PR DESCRIPTION
Taken from the Fedora sources: https://src.fedoraproject.org/rpms/python-qrcode/raw/rawhide/f/qrcode_assert-has-calls.patch
