### PR TITLE
Allow setting embedded image size in relation to the QR code width

### DIFF
--- a/qrcode/image/styledpil.py
+++ b/qrcode/image/styledpil.py
@@ -32,6 +32,8 @@ class StyledPilImage(qrcode.image.base.BaseImageWithDrawer):
     data integrity A resampling filter can be specified (defaulting to
     PIL.Image.Resampling.LANCZOS) for resizing; see PIL.Image.resize() for possible
     options for this parameter.
+    The image size can be controlled by `embeded_image_ratio` which is a ratio
+    between 0 and 1 that's set in relation to the overall width of the QR code.
     """
 
     kind = "PNG"
@@ -44,6 +46,7 @@ class StyledPilImage(qrcode.image.base.BaseImageWithDrawer):
         self.color_mask = kwargs.get("color_mask", SolidFillColorMask())
         embeded_image_path = kwargs.get("embeded_image_path", None)
         self.embeded_image = kwargs.get("embeded_image", None)
+        self.embeded_image_ratio = kwargs.get("embeded_image_ratio", 0.25)
         self.embeded_image_resample = kwargs.get(
             "embeded_image_resample", Image.Resampling.LANCZOS
         )
@@ -87,7 +90,7 @@ class StyledPilImage(qrcode.image.base.BaseImageWithDrawer):
             return
         total_width, _ = self._img.size
         total_width = int(total_width)
-        logo_width_ish = int(total_width / 4)
+        logo_width_ish = int(total_width * self.embeded_image_ratio)
         logo_offset = (
             int((int(total_width / 2) - int(logo_width_ish / 2)) / self.box_size)
             * self.box_size

--- a/qrcode/tests/test_qrcode.py
+++ b/qrcode/tests/test_qrcode.py
@@ -212,6 +212,14 @@ class QRCodeTests(unittest.TestCase):
         img.save(io.BytesIO())
 
     @unittest.skipIf(not pil_Image, "Requires PIL")
+    def test_render_styled_with_embeded_image_and_ratio(self):
+        embeded_img = pil_Image.new("RGB", (10, 10), color="red")
+        qr = qrcode.QRCode(error_correction=qrcode.ERROR_CORRECT_L)
+        qr.add_data(UNICODE_TEXT)
+        img = qr.make_image(image_factory=StyledPilImage, embeded_image=embeded_img, embeded_image_ratio=0.3)
+        img.save(io.BytesIO())
+
+    @unittest.skipIf(not pil_Image, "Requires PIL")
     def test_render_styled_with_embeded_image_path(self):
         tmpfile = os.path.join(self.tmpdir, "test.png")
         embeded_img = pil_Image.new("RGB", (10, 10), color="red")


### PR DESCRIPTION
When adding an embedded image to the QR code, one can now control the size of this embedded image with a ratio that is in relation to the overall size of the QR code.