### PR TITLE
Add buffer and fileno for mocked sys.stdout

### DIFF
--- a/qrcode/tests/test_script.py
+++ b/qrcode/tests/test_script.py
@@ -30,6 +30,8 @@ class ScriptTest(unittest.TestCase):
     @mock.patch("sys.stdout")
     @unittest.skipIf(not Image, "Requires PIL")
     def test_piped(self, mock_stdout):
+        mock_stdout.buffer = io.BytesIO()
+        mock_stdout.fileno = lambda: 999
         main(["testtext"])
 
     @mock.patch("os.isatty", lambda *args: True)
@@ -61,6 +63,7 @@ class ScriptTest(unittest.TestCase):
 
     @mock.patch("sys.stdout")
     def test_factory(self, mock_stdout):
+        mock_stdout.buffer = io.BytesIO()
         main("testtext --factory svg".split())
 
     @mock.patch("sys.stderr")


### PR DESCRIPTION
This PR tries to fix two failing tests, `test_factory` and `test_pipe`, reported in https://github.com/lincolnloop/python-qrcode/issues/355 and https://github.com/lincolnloop/python-qrcode/issues/361. The issue seems to be related to mocked `sys.stdout` because the mocked object is probably missing certain attributes or methods that need to be emulated.

Both tests start to work for me again with this change.