### PR TITLE
Allow correct spelling of parameters.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,7 +211,7 @@ circles by reducing this less than the default of ``Decimal(1)``.
 
 The ``StyledPilImage`` additionally accepts an optional ``color_mask``
 parameter to change the colors of the QR Code, and an optional
-``embeded_image_path`` to embed an image in the center of the code.
+``embedded_image_path`` to embed an image in the center of the code.
 
 Other color masks:
 
@@ -232,7 +232,7 @@ and an embedded image:
 
     img_1 = qr.make_image(image_factory=StyledPilImage, module_drawer=RoundedModuleDrawer())
     img_2 = qr.make_image(image_factory=StyledPilImage, color_mask=RadialGradiantColorMask())
-    img_3 = qr.make_image(image_factory=StyledPilImage, embeded_image_path="/path/to/image.png")
+    img_3 = qr.make_image(image_factory=StyledPilImage, embedded_image_path="/path/to/image.png")
 
 Examples
 ========

--- a/qrcode/image/styledpil.py
+++ b/qrcode/image/styledpil.py
@@ -41,11 +41,18 @@ class StyledPilImage(qrcode.image.base.BaseImageWithDrawer):
 
     def __init__(self, *args, **kwargs):
         self.color_mask = kwargs.get("color_mask", SolidFillColorMask())
-        embeded_image_path = kwargs.get("embeded_image_path", None)
-        self.embeded_image = kwargs.get("embeded_image", None)
-        self.embeded_image_ratio = kwargs.get("embeded_image_ratio", 0.25)
+        embeded_image_path = kwargs.get(
+            "embeded_image_path",
+            kwargs.get("embedded_image_path", None))
+        self.embeded_image = kwargs.get(
+            "embeded_image",
+            kwargs.get("embedded_image", None))
+        self.embeded_image_ratio = kwargs.get(
+            "embeded_image_ratio",
+            kwargs.get("embedded_image_ratio", 0.25))
         self.embeded_image_resample = kwargs.get(
-            "embeded_image_resample", Image.Resampling.LANCZOS
+            "embeded_image_resample",
+            kwargs.get("embedded_image_resample", Image.Resampling.LANCZOS)
         )
         if not self.embeded_image and embeded_image_path:
             self.embeded_image = Image.open(embeded_image_path)


### PR DESCRIPTION
I wasted 3 hours of my life while this library silently ignored the proper spelling of the parameter `embedded_image`.

https://www.merriam-webster.com/dictionary/embedded

This PR will allow the proper spelling as well as the incorrect legacy spelling. Hopefully this saves someone some time.