### PR TITLE
Do not set element id for path generated by SvgPathImage

### DIFF
--- a/qrcode/image/svg.py
+++ b/qrcode/image/svg.py
@@ -152,7 +152,6 @@ class SvgPathImage(SvgImage):
         self.path = ET.Element(
             ET.QName("path"),  # type: ignore
             d="".join(self._subpaths),
-            id="qr-path",
             **self.QR_PATH_STYLE,
         )
         self._subpaths = []


### PR DESCRIPTION
The element id used is hardcoded, which may cause issues when inlining many qr codes in a single document.

Proposed fix for #384.