### PR TITLE
Added support for environments where the FloatOperation signal is trapped in the Decimal library

### DIFF
--- a/qrcode/image/svg.py
+++ b/qrcode/image/svg.py
@@ -84,8 +84,8 @@ class SvgImage(SvgFragmentImage):
     background: Optional[str] = None
     drawer_aliases: qrcode.image.base.DrawerAliases = {
         "circle": (svg_drawers.SvgCircleDrawer, {}),
-        "gapped-circle": (svg_drawers.SvgCircleDrawer, {"size_ratio": Decimal(0.8)}),
-        "gapped-square": (svg_drawers.SvgSquareDrawer, {"size_ratio": Decimal(0.8)}),
+        "gapped-circle": (svg_drawers.SvgCircleDrawer, {"size_ratio": Decimal("0.8")}),
+        "gapped-square": (svg_drawers.SvgSquareDrawer, {"size_ratio": Decimal("0.8")}),
     }
 
     def _svg(self, tag="svg", **kwargs):
@@ -128,11 +128,11 @@ class SvgPathImage(SvgImage):
         "circle": (svg_drawers.SvgPathCircleDrawer, {}),
         "gapped-circle": (
             svg_drawers.SvgPathCircleDrawer,
-            {"size_ratio": Decimal(0.8)},
+            {"size_ratio": Decimal("0.8")},
         ),
         "gapped-square": (
             svg_drawers.SvgPathSquareDrawer,
-            {"size_ratio": Decimal(0.8)},
+            {"size_ratio": Decimal("0.8")},
         ),
     }
 


### PR DESCRIPTION
From [Python's Decimal module Quick-start Tutorial](https://docs.python.org/3/library/decimal.html#quick-start-tutorial):

> If the [FloatOperation](https://docs.python.org/3/library/decimal.html#decimal.FloatOperation) signal is trapped, accidental mixing of decimals and floats in constructors or ordering comparisons raises an exception

This is used to prevent loss of precision by using floats before converting to Decimal. This was happening in a couple of places in this library, which prevented me from using it in such an environment. The fix is pretty simple, presumably without changing any functionality for anyone.