### PR TITLE
Shift the image factory code to work with the output parameter

### DIFF
--- a/qrcode/console_scripts.py
+++ b/qrcode/console_scripts.py
@@ -112,7 +112,7 @@ def main(args=None):
     else:
         qr.add_data(data, optimize=opts.optimize)
 
-    if image_factory is None and (os.isatty(sys.stdout.fileno()) or opts.ascii):
+    if opts.ascii:
         qr.print_ascii(tty=not opts.ascii)
         return
 


### PR DESCRIPTION
The code for handling an image factory and the various drawers doesn't work unless the output is sent to stdout.  This slightly shifts ordering of processing, to ensure that when outputting to a file, the various command line options and flags are taken into consideration.

I don't know if I was missing some reason that the `output` parameter always skipped all other options, but it was quite confusing, so I looked into it and it seemed like this mechanism could work?  It should have minimal impact on the ascii output, but it does now require that the ascii flag is specified and will *always* output ascii if it is.  Hopefully that's ok...