### PR TITLE
Use standardized [project] table in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,16 @@
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=2"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.poetry]
+[project]
 name = "qrcode"
 version = "8.2"
-packages = [{include = "qrcode"}]
 description = "QR Code image generator"
-authors = ["Lincoln Loop <info@lincolnloop.com>"]
-license = "BSD"
-readme = ["README.rst", "CHANGES.rst"]
-homepage = "https://github.com/lincolnloop/python-qrcode"
+authors = [
+    { name = "Lincoln Loop", email = "info@lincolnloop.com" },
+]
+license = { text = "BSD-3-Clause" }
+dynamic = [ "readme" ]
 keywords = ["qr", "denso-wave", "IEC18004"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -28,6 +28,25 @@ classifiers = [
     "Topic :: Multimedia :: Graphics",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
+requires-python = "~=3.9"
+dependencies = [
+    "colorama; sys_platform == 'win32'",
+]
+
+[project.optional-dependencies]
+pil = ["pillow >=9.1.0"]
+png = ["pypng"]
+all = ["pypng", "pillow >=9.1.0"]
+
+[project.urls]
+homepage = "https://github.com/lincolnloop/python-qrcode"
+
+[project.scripts]
+qr = "qrcode.console_scripts:main"
+
+[tool.poetry]
+packages = [{include = "qrcode"}]
+readme = ["README.rst", "CHANGES.rst"]
 
 # There is no support for data files yet.
 # https://github.com/python-poetry/poetry/issues/9519
@@ -35,21 +54,6 @@ classifiers = [
 # data_files = [
 #     { destination = "share/man/man1", from = [ "doc/qr.1" ] },
 # ]
-
-[tool.poetry.scripts]
-qr = 'qrcode.console_scripts:main'
-
-
-[tool.poetry.dependencies]
-python = "^3.9"
-colorama = {version = "*", platform = "win32"}
-pypng = {version = "*", optional = true}
-pillow = {version = ">=9.1.0", optional = true}
-
-[tool.poetry.extras]
-pil = ["pillow"]
-png = ["pypng"]
-all = ["pypng","pillow"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = {version = "*"}


### PR DESCRIPTION
This allows us to swap the build backend more easily in RHEL, where we don't have poetry-code.

This requires poetry-core >= 2 because older poetry did not support this.

Also, replace the value of the license text with a SPDX identifier as documented in https://python-poetry.org/docs/pyproject/#license
Otherwise, poetry-core injects a `Other/Proprietary License` classifier. (Note that poetry-core does not yet support PEP 639 fully).

This change creates s slight change in the metadata, comments inline.

    --- old/qrcode-8.2-py3-none-any/qrcode-8.2.dist-info/METADATA
    +++ new/qrcode-8.2-py3-none-any/qrcode-8.2.dist-info/METADATA
    @@ -2,16 +2,15 @@
     Name: qrcode
     Version: 8.2
     Summary: QR Code image generator
    -License: BSD
    +License: BSD-3-Clause

This was intentional.

     Keywords: qr,denso-wave,IEC18004
     Author: Lincoln Loop
     Author-email: info@lincolnloop.com
    -Requires-Python: >=3.9,<4.0
    +Requires-Python: ~=3.9

This is identical in reality.

     Classifier: Development Status :: 5 - Production/Stable
    -Classifier: Intended Audience :: Developers

This only changes order :/

     Classifier: License :: OSI Approved :: BSD License
    -Classifier: License :: Other/Proprietary License

This is intentional.

     Classifier: Operating System :: OS Independent
    +Classifier: Intended Audience :: Developers

See above, order only.

     Classifier: Programming Language :: Python
     Classifier: Programming Language :: Python :: 3
     Classifier: Programming Language :: Python :: 3.9
    @@ -26,8 +25,10 @@
     Provides-Extra: pil
     Provides-Extra: png
     Requires-Dist: colorama ; sys_platform == "win32"
    -Requires-Dist: pillow (>=9.1.0) ; extra == "pil" or extra == "all"
    -Requires-Dist: pypng ; extra == "png" or extra == "all"
    +Requires-Dist: pillow (>=9.1.0) ; extra == "all"
    +Requires-Dist: pillow (>=9.1.0) ; extra == "pil"
    +Requires-Dist: pypng ; extra == "all"
    +Requires-Dist: pypng ; extra == "png"

This is identical.

     Project-URL: Homepage, https://github.com/lincolnloop/python-qrcode
     Description-Content-Type: text/x-rst