### PR TITLE
Fix `<svg:` prefix in the SVG output causing invalid markup when inlined within HTML documents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,9 +38,10 @@ WIP
 - **Added** ``GappedCircleModuleDrawer`` (PIL) to render QR code modules as non-contiguous circles. (BenwestGate in `#373`_)
 - **Added** ability to execute as a Python module: ``python -m qrcode --output qrcode.png "hello world"`` (stefansjs in `#400`_)
 - **Removed** the hardcoded 'id' argument from SVG elements. The fixed element ID caused conflicts when embedding multiple QR codes in a single document. (m000 in `#385`_)
-- Improved test coveraged (akx in `#315`_)
-- Fixed typos in code that used ``embeded`` instead of ``embedded``. For backwards compatibility, the misspelled parameter names are still accepted but now emit deprecation warnings. These deprecated parameter names will be removed in v9.0. (benjnicholls in `#349`_)
+- **Fixed** typos in code that used ``embeded`` instead of ``embedded``. For backwards compatibility, the misspelled parameter names are still accepted but now emit deprecation warnings. These deprecated parameter names will be removed in v9.0. (benjnicholls in `#349`_)
+- **Fixed** an issue where an ``<svg:`` prefix in the SVG output caused invalid markup when inlined within HTML documents. (bartTC in `#412`_)
 - Migrate pyproject.toml to PEP 621-compliant [project] metadata format. (hroncok in `#399`_)
+- Improved test coveraged (akx in `#315`_)
 - Implement Ruff rules and perform comprehensive code cleanup.
 
 .. _#315: https://github.com/lincolnloop/python-qrcode/pull/315
@@ -49,6 +50,7 @@ WIP
 .. _#385: https://github.com/lincolnloop/python-qrcode/pull/385
 .. _#399: https://github.com/lincolnloop/python-qrcode/pull/399
 .. _#400: https://github.com/lincolnloop/python-qrcode/pull/400
+.. _#412: https://github.com/lincolnloop/python-qrcode/pull/412
 
 8.2 (01 May 2025)
 -----------------

--- a/qrcode/image/styles/moduledrawers/svg.py
+++ b/qrcode/image/styles/moduledrawers/svg.py
@@ -53,7 +53,8 @@ class SvgQRModuleDrawer(BaseSvgQRModuleDrawer):
 
     def initialize(self, *args, **kwargs) -> None:
         super().initialize(*args, **kwargs)
-        self.tag_qname = ET.QName(self.img._SVG_namespace, self.tag)
+        # Use tag directly instead of QName with namespace to avoid svg: prefix in output
+        self.tag_qname = self.tag
 
     def drawrect(self, box, is_active: bool):
         if not is_active:

--- a/qrcode/image/styles/moduledrawers/svg.py
+++ b/qrcode/image/styles/moduledrawers/svg.py
@@ -53,8 +53,6 @@ class SvgQRModuleDrawer(BaseSvgQRModuleDrawer):
 
     def initialize(self, *args, **kwargs) -> None:
         super().initialize(*args, **kwargs)
-        # Use tag directly instead of QName with namespace to avoid svg: prefix in output
-        self.tag_qname = self.tag
 
     def drawrect(self, box, is_active: bool):
         if not is_active:
@@ -73,7 +71,7 @@ class SvgSquareDrawer(SvgQRModuleDrawer):
     def el(self, box):
         coords = self.coords(box)
         return ET.Element(
-            self.tag_qname,
+            self.tag,
             x=self.img.units(coords.x0),
             y=self.img.units(coords.y0),
             width=self.unit_size,
@@ -91,7 +89,7 @@ class SvgCircleDrawer(SvgQRModuleDrawer):
     def el(self, box):
         coords = self.coords(box)
         return ET.Element(
-            self.tag_qname,
+            self.tag,
             cx=self.img.units(coords.xh),
             cy=self.img.units(coords.yh),
             r=self.radius,

--- a/qrcode/tests/regression/test_svg_rect.py
+++ b/qrcode/tests/regression/test_svg_rect.py
@@ -1,0 +1,44 @@
+import io
+
+import pytest
+
+import qrcode
+from qrcode.image import svg
+from qrcode.tests.consts import UNICODE_TEXT
+
+
+@pytest.mark.parametrize(
+    "image_factory",
+    [
+        svg.SvgFillImage,
+        svg.SvgFragmentImage,
+        svg.SvgImage,
+        svg.SvgPathFillImage,
+        # svg.SvgPathImage,  # Result does not contain <rect elements
+    ],
+)
+def test_svg_no_namespace_prefix(image_factory: svg.SvgFragmentImage):
+    """
+    Test that SVG output doesn't contain <svg:rect> elements.
+
+    This regression test ensures that rect elements in SVG output are rendered as
+    <rect> without the svg: namespace prefix, which can cause rendering issues in
+    browsers, when loaded in HTML.
+
+    https://github.com/lincolnloop/python-qrcode/issues/353
+    https://github.com/lincolnloop/python-qrcode/issues/317
+    """
+    # Create a QR code
+    qr = qrcode.QRCode()
+    qr.add_data(UNICODE_TEXT)
+
+    img = qr.make_image(image_factory=image_factory)
+    f = io.BytesIO()
+    img.save(f)
+    svg_content = f.getvalue().decode("utf-8")
+
+    # Check that there are no <svg:rect> elements in the output
+    assert "<svg:rect" not in svg_content
+
+    # Check that there are <rect> elements in the output
+    assert "<rect" in svg_content


### PR DESCRIPTION
Fixes #317
Fixes #353
